### PR TITLE
Problem: missing basic account query and tx broadcast support (fixes #29)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +265,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
 name = "cosmos-sdk-proto"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,7 +288,8 @@ checksum = "edb5204c6ddc4352c74297638b5561f2929d6334866c156e5f3c75e1e1a1436a"
 dependencies = [
  "prost",
  "prost-types",
- "tendermint-proto",
+ "tendermint-proto 0.23.2",
+ "tonic",
 ]
 
 [[package]]
@@ -287,7 +310,7 @@ dependencies = [
  "serde",
  "serde_json",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.23.2",
  "thiserror",
 ]
 
@@ -336,16 +359,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "defi-wallet-core-common"
 version = "0.1.0"
 dependencies = [
+ "cosmos-sdk-proto",
  "cosmrs",
  "defi-wallet-core-proto",
  "eyre",
  "prost",
  "rand_core 0.6.3",
+ "reqwest",
  "secrecy",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tendermint-rpc",
  "thiserror",
+ "tokio",
+ "tonic",
  "uniffi",
  "uniffi_build",
  "uniffi_macros",
@@ -359,7 +425,7 @@ dependencies = [
  "cosmrs",
  "prost",
  "prost-types",
- "tendermint-proto",
+ "tendermint-proto 0.23.2",
  "tonic",
 ]
 
@@ -370,6 +436,7 @@ dependencies = [
  "console_error_panic_hook",
  "defi-wallet-core-common",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wee_alloc",
 ]
 
@@ -447,6 +514,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +565,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc8cd39e3dbf865f7340dce6a2d401d24fd37c6fe6c4f0ee0de8bfca2252d27"
+checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -526,27 +627,27 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629316e42fe7c2a0b9a65b47d159ceaa5453ab14e8f0a3c5eedbb8cd55b4a445"
+checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
 
 [[package]]
 name = "futures-io"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e481354db6b5c353246ccf6a728b0c5511d752c08da7260546fc0933869daa11"
+checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "996c6442437b62d21a32cd9906f9c41e7dc1e19a9579843fad948696769305af"
+checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
 
 [[package]]
 name = "futures-task"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabf1872aaab32c886832f2276d2f5399887e2bd613698a02359e4ea83f8de12"
+checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
 
 [[package]]
 name = "futures-util"
@@ -556,10 +657,13 @@ checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
  "autocfg",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -634,6 +738,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -731,6 +844,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +888,12 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
@@ -824,6 +973,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,6 +989,12 @@ name = "memory_units"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mio"
@@ -862,6 +1023,24 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "native-tls"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "nom"
@@ -916,6 +1095,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,6 +1115,39 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "paste"
@@ -941,6 +1163,33 @@ checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
 dependencies = [
  "crypto-mac",
 ]
+
+[[package]]
+name = "peg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c0b841ea54f523f7aa556956fbd293bcbe06f2e67d2eb732b7278aaf1d166a"
+dependencies = [
+ "peg-macros",
+ "peg-runtime",
+]
+
+[[package]]
+name = "peg-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5aa52829b8decbef693af90202711348ab001456803ba2a98eb4ec8fb70844c"
+dependencies = [
+ "peg-runtime",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "peg-runtime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c719dcf55f09a3a7e764c6649ab594c18a177e3599c467983cdf644bfc0a4088"
 
 [[package]]
 name = "percent-encoding"
@@ -1008,6 +1257,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "ppv-lite86"
@@ -1224,6 +1479,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c4e0a76dc12a116108933f6301b95e83634e0c47b0afbed6abbaa0601e99258"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "ripemd160"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,6 +1538,37 @@ dependencies = [
  "digest",
  "opaque-debug",
 ]
+
+[[package]]
+name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "ryu"
@@ -1250,12 +1586,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1329,6 +1708,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6056b4cb69b6e43e3a0f055def223380baecc99da683884f205bf347f7c4b3"
+dependencies = [
+ "rustversion",
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12e47be9471c72889ebafb5e14d5ff930d89ae7a67bbdb5f8abb564f845a927e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,6 +1794,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
 name = "spki"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,6 +1813,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -1488,9 +1914,50 @@ dependencies = [
  "signature",
  "subtle",
  "subtle-encoding",
- "tendermint-proto",
+ "tendermint-proto 0.23.2",
  "time",
  "zeroize",
+]
+
+[[package]]
+name = "tendermint"
+version = "0.23.3"
+source = "git+https://github.com/informalsystems/tendermint-rs.git?rev=v0.23.3#4a48416c351b6d5fda96a6e32a7fb0e341126e2a"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "ed25519",
+ "ed25519-dalek",
+ "flex-error",
+ "futures",
+ "num-traits",
+ "once_cell",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_repr",
+ "sha2",
+ "signature",
+ "subtle",
+ "subtle-encoding",
+ "tendermint-proto 0.23.3",
+ "time",
+ "zeroize",
+]
+
+[[package]]
+name = "tendermint-config"
+version = "0.23.3"
+source = "git+https://github.com/informalsystems/tendermint-rs.git?rev=v0.23.3#4a48416c351b6d5fda96a6e32a7fb0e341126e2a"
+dependencies = [
+ "flex-error",
+ "serde",
+ "serde_json",
+ "tendermint 0.23.3",
+ "toml",
+ "url",
 ]
 
 [[package]]
@@ -1509,6 +1976,47 @@ dependencies = [
  "serde_bytes",
  "subtle-encoding",
  "time",
+]
+
+[[package]]
+name = "tendermint-proto"
+version = "0.23.3"
+source = "git+https://github.com/informalsystems/tendermint-rs.git?rev=v0.23.3#4a48416c351b6d5fda96a6e32a7fb0e341126e2a"
+dependencies = [
+ "bytes",
+ "flex-error",
+ "num-derive",
+ "num-traits",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
+ "time",
+]
+
+[[package]]
+name = "tendermint-rpc"
+version = "0.23.3"
+source = "git+https://github.com/informalsystems/tendermint-rs.git?rev=v0.23.3#4a48416c351b6d5fda96a6e32a7fb0e341126e2a"
+dependencies = [
+ "bytes",
+ "flex-error",
+ "getrandom",
+ "peg",
+ "pin-project",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "subtle-encoding",
+ "tendermint 0.23.3",
+ "tendermint-config",
+ "tendermint-proto 0.23.3",
+ "thiserror",
+ "time",
+ "url",
+ "uuid",
+ "walkdir",
 ]
 
 [[package]]
@@ -1557,6 +2065,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
 
 [[package]]
+name = "tinyvec"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "tokio"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,6 +2089,7 @@ dependencies = [
  "libc",
  "memchr",
  "mio",
+ "num_cpus",
  "pin-project-lite",
  "tokio-macros",
  "winapi",
@@ -1590,6 +2114,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -1647,7 +2192,9 @@ dependencies = [
  "pin-project",
  "prost",
  "prost-derive",
+ "rustls-native-certs",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-util",
  "tower",
@@ -1764,6 +2311,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,6 +2399,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,6 +2468,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
  "cfg-if 1.0.0",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -1892,6 +2486,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1922,6 +2528,26 @@ name = "wasm-bindgen-shared"
 version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+
+[[package]]
+name = "web-sys"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "wee_alloc"
@@ -1985,6 +2611,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "proto-build",
     "proto",

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -11,7 +11,8 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 defi-wallet-core-common = { path = "../../common" }
-wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,10 +12,23 @@ cosmrs = "0.3"
 defi-wallet-core-proto = { version = "0.1", default-features = false, path = "../proto" }
 prost = "0.9"
 rand_core = { version = "0.6", features = ["std"] }
+reqwest = { version = "0.11", features = ["blocking", "json"] }
 secrecy = "0.8"
+serde = "1"
+serde_json = "1"
+serde_with = "1"
+# FIXME: unify with crates.io (depends on the upstream fixes in CosmRS)
+# Currently, it needs this separate one, because CosmRS is fixed to 0.23.2 (it'll fail to compile with 0.23.3)
+# and 0.32.2 includes an old getrandom crate which will have a runtime error in WASM/JS.
+tendermint-rpc = { git = "https://github.com/informalsystems/tendermint-rs.git", rev = "v0.23.3" } 
 thiserror = "1"
 uniffi = "^0.15"
 uniffi_macros = "^0.15"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+cosmos-sdk-proto = { version = "0.8", features = ["grpc"] }
+tokio = { version = "1", features = ["rt"] }
+tonic = { version = "0.6", features = ["tls", "tls-roots"] }
 
 [build-dependencies]
 uniffi_build = { version = "^0.15", features=["builtin-bindgen"] }

--- a/common/src/common.udl
+++ b/common/src/common.udl
@@ -82,9 +82,76 @@ enum ErrorWrapper {
   "PubkeyError",
 };
 
+[Error]
+enum RestError {
+  "RequestError",
+  "MissingResult",
+  "AsyncRuntimeError",
+  "GRPCError",
+};
+
+dictionary RawRpcBalance {
+    string denom;
+    string amount;
+};
+
+dictionary RawRpcPubKey {
+    string pub_key_type;
+    string key;
+};
+
+dictionary RawRpcAccountStatus {
+    string account_type;
+    string address;
+    RawRpcPubKey pub_key;
+    u64 account_number;
+    u64 sequence;
+};
+
+[Enum]
+interface RawRpcAccountResponse {
+  OkResponse(RawRpcAccountStatus account);
+  ErrorResponse(i64 code, string message, sequence<string> details);
+};
+
+enum BalanceApiVersion {
+  "Old",
+  "New",
+};
+
+dictionary TxBroadcastResult {
+    string tx_hash_hex;
+    u32 code;
+    string log;
+};
+
+interface CosmosSDKClient {
+    constructor(string tendermint_rpc_url, string rest_api_url, BalanceApiVersion balance_api_version, string grpc_url);
+
+    [Throws=RestError]
+    TxBroadcastResult broadcast_tx(sequence<u8> raw_signed_tx);
+
+    [Throws=RestError]
+    RawRpcBalance get_account_balance([ByRef] string address, [ByRef] string denom);
+
+    [Throws=RestError]
+    RawRpcAccountResponse get_account_details([ByRef] string address);
+
+    [Throws=RestError]
+    u64 simulate(sequence<u8> raw_signed_tx);
+};
+
 namespace common {
   [Throws=ErrorWrapper]
   sequence<u8> get_single_msg_sign_payload(CosmosSDKTxInfo tx_info, CosmosSDKMsg msg, PublicKeyBytesWrapper sender_pubkey);
   [Throws=ErrorWrapper]
   sequence<u8> build_signed_single_msg_tx(CosmosSDKTxInfo tx_info, CosmosSDKMsg msg, SecretKey secret_key);
+  [Throws=RestError]
+  RawRpcAccountResponse get_account_details_blocking([ByRef] string api_url, [ByRef] string address);
+  [Throws=RestError]
+  RawRpcBalance get_account_balance_blocking([ByRef] string api_url, [ByRef] string address, [ByRef] string denom, BalanceApiVersion version);
+  [Throws=RestError]
+  u64 simulate_blocking([ByRef] string grpc_url, sequence<u8> raw_signed_tx);
+  [Throws=RestError]
+  TxBroadcastResult broadcast_tx_sync_blocking([ByRef] string tendermint_rpc_url, sequence<u8> raw_signed_tx);
 };

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,3 +1,5 @@
+/// interactions with remote node RPC / API (querying, broadcast etc.)
+mod node;
 /// transaction building etc.
 mod transaction;
 /// HD wallet-related functionality
@@ -9,6 +11,8 @@ pub use eyre::{Report as ErrorReport, Result};
 
 pub use cosmrs::{tx::Msg, AccountId};
 
+pub use node::*;
 pub use transaction::*;
 pub use wallet::*;
+#[cfg(not(target_arch = "wasm32"))]
 uniffi_macros::include_scaffolding!("common");

--- a/common/src/node.rs
+++ b/common/src/node.rs
@@ -1,0 +1,5 @@
+/// wrappers around Cosmos SDK REST API and Tendermint RPC
+/// FIXME: switch to grpc when grpc-web works in CosmRS: https://github.com/cosmos/cosmos-rust/pull/157
+mod cosmos_sdk;
+
+pub use cosmos_sdk::*;

--- a/common/src/node/cosmos_sdk.rs
+++ b/common/src/node/cosmos_sdk.rs
@@ -1,0 +1,313 @@
+#[cfg(not(target_arch = "wasm32"))]
+use cosmos_sdk_proto::cosmos::tx::v1beta1::{service_client::ServiceClient, SimulateRequest};
+use serde::{Deserialize, Serialize};
+use tendermint_rpc::{endpoint::broadcast::tx_sync, request, response};
+
+/// wrapper around API errors
+#[derive(Debug, thiserror::Error)]
+pub enum RestError {
+    #[error("HTTP request error: {0}")]
+    RequestError(reqwest::Error),
+    #[error("Missing result in the JSON-RPC response")]
+    MissingResult,
+    #[error("Async Runtime error")]
+    AsyncRuntimeError,
+    #[error("gRPC error")]
+    GRPCError,
+}
+
+/// Response from the balance API
+#[derive(Serialize, Deserialize)]
+pub struct BalanceResponse {
+    balance: RawRpcBalance,
+}
+
+/// The raw balance data from the balance API
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RawRpcBalance {
+    /// denomination
+    pub denom: String,
+    /// the decimal number of coins of a given denomination
+    pub amount: String,
+}
+
+/// The raw response from the account API
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum RawRpcAccountResponse {
+    /// the account was found
+    OkResponse {
+        /// the account details
+        account: RawRpcAccountStatus,
+    },
+    /// error response -- usually when the account doesn't exit on-chain yet
+    ErrorResponse {
+        /// https://github.com/cosmos/cosmos-sdk/blob/9566c99185ad5ae64a56884d924ee354f211e6dd/types/errors/errors.go
+        code: i64,
+        /// the reason for failure
+        message: String,
+        /// usually empty; ignored for now
+        #[serde(skip)]
+        details: Vec<String>,
+    },
+}
+
+/// the raw account status data from the account API
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RawRpcAccountStatus {
+    /// the protobuf type
+    #[serde(rename = "@type")]
+    pub account_type: String,
+    /// the bech32 address
+    pub address: String,
+    /// the associated public key
+    pub pub_key: RawRpcPubKey,
+    /// the global account number
+    #[serde(with = "serde_with::rust::display_fromstr")]
+    pub account_number: u64,
+    /// the sequence number / nonce
+    #[serde(with = "serde_with::rust::display_fromstr")]
+    pub sequence: u64,
+}
+
+/// the raw pubkey data returned from the account API
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RawRpcPubKey {
+    /// the protobuf type
+    #[serde(rename = "@type")]
+    pub pub_key_type: String,
+    /// the pubkey payload encoded in base64
+    pub key: String,
+}
+
+/// the version of balance API
+/// see the breaking change: https://github.com/cosmos/cosmos-sdk/releases/tag/v0.42.11
+#[derive(Clone, Copy)]
+pub enum BalanceApiVersion {
+    /// before 0.42.11 or 0.44.4
+    Old,
+    /// after 0.42.11 or 0.44.4
+    New,
+}
+
+fn get_accounts_url(api_url: &str, address: &str) -> String {
+    format!("{}/cosmos/auth/v1beta1/accounts/{}", api_url, address)
+}
+
+fn get_balance_url(
+    api_url: &str,
+    address: &str,
+    denom: &str,
+    version: BalanceApiVersion,
+) -> String {
+    match version {
+        BalanceApiVersion::New => format!(
+            "{}/cosmos/bank/v1beta1/balances/{}/by_denom?denom={}",
+            api_url, address, denom
+        ),
+        BalanceApiVersion::Old => format!(
+            "{}/cosmos/bank/v1beta1/balances/{}/{}",
+            api_url, address, denom
+        ),
+    }
+}
+
+/// return the account details (async for JS/WASM)
+pub async fn get_account_details(
+    api_url: &str,
+    address: &str,
+) -> Result<RawRpcAccountResponse, RestError> {
+    let resp = reqwest::Client::new()
+        .get(get_accounts_url(api_url, address))
+        .send()
+        .await
+        .map_err(RestError::RequestError)?
+        .json::<RawRpcAccountResponse>()
+        .await
+        .map_err(RestError::RequestError)?;
+    Ok(resp)
+}
+
+/// return the account details (blocking for other platforms;
+/// platform-guarded as JS/WASM doesn't support the reqwest blocking)
+#[cfg(not(target_arch = "wasm32"))]
+pub fn get_account_details_blocking(
+    api_url: &str,
+    address: &str,
+) -> Result<RawRpcAccountResponse, RestError> {
+    let resp = reqwest::blocking::get(get_accounts_url(api_url, address))
+        .map_err(RestError::RequestError)?
+        .json::<RawRpcAccountResponse>()
+        .map_err(RestError::RequestError)?;
+    Ok(resp)
+}
+
+/// given the gRPC endpoint and the raw signed transaction bytes,
+/// it'll submit the transaction for simulating its execution and return the used gas.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn simulate_blocking(gprc_url: &str, tx: Vec<u8>) -> Result<u64, RestError> {
+    let rt = tokio::runtime::Runtime::new().map_err(|_err| RestError::AsyncRuntimeError)?;
+    let result = rt.block_on(async move {
+        let mut client = ServiceClient::connect(gprc_url.to_owned())
+            .await
+            .map_err(|_err| RestError::GRPCError)?;
+        let request = SimulateRequest {
+            tx_bytes: tx,
+            ..Default::default()
+        };
+        let res = client
+            .simulate(request)
+            .await
+            .map_err(|_err| RestError::GRPCError)?;
+        res.into_inner().gas_info.ok_or(RestError::MissingResult)
+    })?;
+    Ok(result.gas_used)
+}
+
+/// return the balance (async for JS/WASM)
+pub async fn get_account_balance(
+    api_url: &str,
+    address: &str,
+    denom: &str,
+    version: BalanceApiVersion,
+) -> Result<RawRpcBalance, RestError> {
+    let resp = reqwest::Client::new()
+        .get(get_balance_url(api_url, address, denom, version))
+        .send()
+        .await
+        .map_err(RestError::RequestError)?
+        .json::<BalanceResponse>()
+        .await
+        .map_err(RestError::RequestError)?;
+    Ok(resp.balance)
+}
+
+/// return the balance (blocking for other platforms;
+/// platform-guarded as JS/WASM doesn't support the reqwest blocking)
+#[cfg(not(target_arch = "wasm32"))]
+pub fn get_account_balance_blocking(
+    api_url: &str,
+    address: &str,
+    denom: &str,
+    version: BalanceApiVersion,
+) -> Result<RawRpcBalance, RestError> {
+    let resp = reqwest::blocking::get(get_balance_url(api_url, address, denom, version))
+        .map_err(RestError::RequestError)?
+        .json::<BalanceResponse>()
+        .map_err(RestError::RequestError)?;
+    Ok(resp.balance)
+}
+
+/// broadcast the tx (async for JS/WASM)
+pub async fn broadcast_tx_sync(
+    tendermint_rpc_url: &str,
+    raw_signed_tx: Vec<u8>,
+) -> Result<response::Wrapper<tx_sync::Response>, RestError> {
+    let request = request::Wrapper::new(tx_sync::Request {
+        tx: raw_signed_tx.into(),
+    });
+
+    Ok(reqwest::Client::new()
+        .post(tendermint_rpc_url)
+        .json(&request)
+        .send()
+        .await
+        .map_err(RestError::RequestError)?
+        .json::<response::Wrapper<tx_sync::Response>>()
+        .await
+        .map_err(RestError::RequestError)?)
+}
+
+/// a subset of `tx_sync::Response` for UniFFI
+#[derive(Debug)]
+pub struct TxBroadcastResult {
+    /// tendermint transaction hash in hexadecimal
+    pub tx_hash_hex: String,
+    /// error code (0 if success)
+    pub code: u32,
+    /// possible error log
+    pub log: String,
+}
+
+/// broadcast the tx (blocking for other platforms;
+/// platform-guarded as JS/WASM doesn't support the reqwest blocking)
+#[cfg(not(target_arch = "wasm32"))]
+pub fn broadcast_tx_sync_blocking(
+    tendermint_rpc_url: &str,
+    raw_signed_tx: Vec<u8>,
+) -> Result<TxBroadcastResult, RestError> {
+    let request = request::Wrapper::new(tx_sync::Request {
+        tx: raw_signed_tx.into(),
+    });
+    let rpc_result = reqwest::blocking::Client::new()
+        .post(tendermint_rpc_url)
+        .json(&request)
+        .send()
+        .map_err(RestError::RequestError)?
+        .json::<response::Wrapper<tx_sync::Response>>()
+        .map_err(RestError::RequestError)?
+        .into_result()
+        .map_err(|_e| RestError::MissingResult)?;
+
+    Ok(TxBroadcastResult {
+        tx_hash_hex: rpc_result.hash.to_string(),
+        code: rpc_result.code.value(),
+        log: rpc_result.log.to_string(),
+    })
+}
+
+/// the client facade for communication with a Cosmos SDK-based node
+#[cfg(not(target_arch = "wasm32"))]
+pub struct CosmosSDKClient {
+    /// the Tendermint JSON-RPC (usually on 26657)
+    tendermint_rpc_url: String,
+    /// the Cosmos REST API (usually on 1317) -- FIXME: replace with grpc-web?
+    rest_api_url: String,
+    /// difference due to a breaking change: https://github.com/cosmos/cosmos-sdk/releases/tag/v0.42.11
+    balance_api_version: BalanceApiVersion,
+    /// the Cosmos gRPC (usually on 9090)
+    grpc_url: String,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl CosmosSDKClient {
+    /// a new client using a set of URLs
+    pub fn new(
+        tendermint_rpc_url: String,
+        rest_api_url: String,
+        balance_api_version: BalanceApiVersion,
+        grpc_url: String,
+    ) -> Self {
+        Self {
+            tendermint_rpc_url,
+            rest_api_url,
+            balance_api_version,
+            grpc_url,
+        }
+    }
+
+    /// broadcast the tx (blocking)
+    pub fn broadcast_tx(&self, raw_signed_tx: Vec<u8>) -> Result<TxBroadcastResult, RestError> {
+        broadcast_tx_sync_blocking(&self.tendermint_rpc_url, raw_signed_tx)
+    }
+
+    /// return the balance (blocking)
+    pub fn get_account_balance(
+        &self,
+        address: &str,
+        denom: &str,
+    ) -> Result<RawRpcBalance, RestError> {
+        get_account_balance_blocking(&self.rest_api_url, address, denom, self.balance_api_version)
+    }
+
+    /// return the account details (blocking)
+    pub fn get_account_details(&self, address: &str) -> Result<RawRpcAccountResponse, RestError> {
+        get_account_details_blocking(&self.rest_api_url, address)
+    }
+
+    /// it'll submit the transaction for simulating its execution and return the used gas.
+    /// (blocking)
+    pub fn simulate(&self, raw_signed_tx: Vec<u8>) -> Result<u64, RestError> {
+        simulate_blocking(&self.grpc_url, raw_signed_tx)
+    }
+}

--- a/common/src/transaction/cosmos_sdk.rs
+++ b/common/src/transaction/cosmos_sdk.rs
@@ -1,6 +1,6 @@
-use std::sync::Arc;
-
-use crate::{SecretKey, UniffiCustomTypeWrapper};
+use crate::SecretKey;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::UniffiCustomTypeWrapper;
 pub use cosmrs::*;
 use cosmrs::{
     bank::MsgSend,
@@ -9,6 +9,7 @@ use cosmrs::{
     tx::{self, Fee, Msg, Raw, SignDoc, SignerInfo},
 };
 use eyre::{eyre, Context};
+use std::sync::Arc;
 
 /// human-readable bech32 prefix for Crypto.org Chain accounts
 pub const CRYPTO_ORG_BECH32_HRP: &str = "cro";
@@ -181,6 +182,7 @@ impl From<PublicKeyBytesWrapper> for PublicKeyBytes {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl UniffiCustomTypeWrapper for PublicKeyBytesWrapper {
     type Wrapped = Vec<u8>;
 

--- a/common/src/wallet.rs
+++ b/common/src/wallet.rs
@@ -28,6 +28,7 @@ pub struct HDWallet {
     mnemonic: Option<Mnemonic>,
 }
 
+/// wrapper around HD Wallet errors
 #[derive(Debug, thiserror::Error)]
 pub enum HdWrapError {
     #[error("The length should be 64-bytes")]

--- a/example/js-example/index.js
+++ b/example/js-example/index.js
@@ -28,3 +28,12 @@ const key = new wasm.PrivateKey();
 const signed_tx = wasm.get_single_bank_send_signed_tx(tx_info, key, "cosmos19dyl0uyzes4k23lscla02n06fc22h4uqsdwq6z",
 BigInt(1000000), "uatom");
 console.log(signed_tx);
+
+const account = await wasm.query_account_details("https://testnet-croeseid-4.crypto.org:1317", "tcro1y6493k3smakl2wf09u7ds4amztx8ks7leyrtmy");
+console.log(account);
+
+const balance = await wasm.query_account_balance("https://testnet-croeseid-4.crypto.org:1317", "tcro1y6493k3smakl2wf09u7ds4amztx8ks7leyrtmy", "basetcro", 0);
+console.log(balance);
+
+const tx_resp = await wasm.broadcast_tx("https://testnet-croeseid-4.crypto.org:26657", signed_tx);
+console.log(tx_resp);

--- a/example/js-example/webpack.config.js
+++ b/example/js-example/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
   },
   mode: "development",
   experiments: {
+    topLevelAwait: true,
     asyncWebAssembly: true
   },
   // FIXME: https://github.com/rust-random/getrandom/issues/224 https://github.com/rustwasm/wasm-pack/issues/822


### PR DESCRIPTION
Solution:
added basic functionality using the reqwest crate
for Cosmos SDK REST API and Tendermint JSON-RPC
(in JS only the async is supported for reqwest using the web-sys client and on UniFFI,
async functions are't supported)
-- TODO: switch to gRPC later when grpc-web works with CosmRS