### PR TITLE
Problem: WASM build is broken by using OsRng of crate rand (fix #95)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,7 +813,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bip39",
- "cfg-if 1.0.0",
  "cosmos-sdk-proto",
  "cosmrs",
  "defi-wallet-core-proto",
@@ -2648,6 +2647,7 @@ dependencies = [
  "libc",
  "rand_core 0.4.2",
  "rdrand",
+ "wasm-bindgen",
  "winapi",
 ]
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -13,7 +13,6 @@ login = ["siwe"]
 [dependencies]
 anyhow = "1"
 bip39 = "1"
-cfg-if = "1"
 eyre = "0.6"
 cosmrs = "0.4"
 defi-wallet-core-proto = { version = "0.1", default-features = false, path = "../proto" }
@@ -22,7 +21,7 @@ ethers = { version = "0.6" }
 prost = "0.9"
 # NOTE: crate `bip39` cannot work with latest crate `rand` (0.8.0)
 # FIXME: https://github.com/rust-bitcoin/rust-bip39/issues/14
-rand = "0.6"
+rand = { version = "0.6", default-features = false, features = ["wasm-bindgen"] }
 rand_core = { version = "0.6", features = ["std"] }
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 secrecy = "0.8"

--- a/common/src/wallet.rs
+++ b/common/src/wallet.rs
@@ -124,15 +124,7 @@ impl HDWallet {
         password: SecretString,
         word_count: MnemonicWordCount,
     ) -> Result<Self, HdWrapError> {
-        // Try to only use OsRng when upgrading `bip39`.
-        cfg_if::cfg_if! {
-            if #[cfg(target_arch = "wasm32")] {
-                let mut rng = rand::rngs::EntropyRng::new();
-            } else {
-                let mut rng = rand::rngs::OsRng::new().map_err(|e| HdWrapError::HDError(e.into()))?;
-            }
-        }
-
+        let mut rng = rand::rngs::OsRng::new().map_err(|e| HdWrapError::HDError(e.into()))?;
         let mnemonic = Mnemonic::generate_in_with(&mut rng, Language::English, word_count.into())
             .map_err(|e| HdWrapError::HDError(e.into()))?;
         let seed = mnemonic.to_seed_normalized(password.expose_secret());


### PR DESCRIPTION
Close #95 

The PR https://github.com/crypto-com/defi-wallet-core-rs/pull/92 added crate `bip39` which could only work with crate `rand-0.6` (cannot use `rand-0.8`). It added this bug to WASM as below:

<img width="600" alt="1" src="https://user-images.githubusercontent.com/88301195/150458897-bdd65ef7-08ab-4d9b-930c-14626bac5408.png">

It is caused by `rand::rngs::OsRng` of `rand-0.6` (not latest version of rand and rand_core). The document of `rand-0.6` mentioned this issue in [the link](https://docs.rs/rand/0.6.0/rand/rngs/struct.OsRng.html#support-for-webassembly-and-amsjs). And it suggests to replace `OsRng` with `EntropyRng` in top of the same [doc page](https://docs.rs/rand/0.6.0/rand/rngs/struct.OsRng.html).

After I fixed to use `EntropyRng`, the error is fixed in browser as below. The wallet API error is related to issue https://github.com/crypto-com/defi-wallet-core-rs/issues/96. I will fix it in another PR. Thanks.

<img width="600" alt="2" src="https://user-images.githubusercontent.com/88301195/150459506-4b5138dd-4c60-4ca7-a203-a5859eb1b038.png">


