### PR TITLE
Problem: An error occurred when building CPP (fix #119)

### DIFF
--- a/example/cpp-example/main.cc
+++ b/example/cpp-example/main.cc
@@ -21,6 +21,8 @@ string getEnv(string key) {
   string ret;
   if (getenv(key.c_str()) != nullptr) {
     ret = getenv(key.c_str());
+  } else {
+      throw std::runtime_error(string("Missing env-").append(key.c_str()));
   }
   return ret;
 }


### PR DESCRIPTION
Close #119

The issue #119 is caused by the missing environment variable `MYMNEMONICS`. The example code passes an empty string to function `restore_wallet`.

It seems that the environment variables are all required in CPP example. So I fix to throw a runtime error if missing one.
@leejw51crypto please help review when you have time. Thanks.