### PR TITLE
Problem: Restrict minimum Rust version to fix Cargo error (fix #153)

### DIFF
--- a/bindings/cpp/Cargo.toml
+++ b/bindings/cpp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "defi-wallet-core-cpp"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.57"
 
 [dependencies]
 defi-wallet-core-common = { path = "../../common" }

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -2,7 +2,6 @@
 name = "defi-wallet-core-wasm"
 version = "0.1.0"
 edition = "2021"
-
 rust-version = "1.57"
 
 [lib]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "defi-wallet-core-common"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib", "staticlib", "rlib"]

--- a/proto-build/Cargo.toml
+++ b/proto-build/Cargo.toml
@@ -3,7 +3,7 @@ name = "proto-build"
 version = "0.1.0"
 edition = "2021"
 publish = false
-
+rust-version = "1.57"
 
 [dependencies]
 prost = "0.9"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 categories = ["cryptography", "cryptography::cryptocurrencies", "database"]
 keywords = ["blockchain", "cosmos", "tendermint", "proto", "crypto.com"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 cosmrs = "0.4"


### PR DESCRIPTION
Close #153 

Restrict minimum Rust version for all sub-crates by adding `rust-version = "1.57"` to `package` section in `Cargo.toml`. Test with Rust `1.57.0` by [asdf](https://github.com/asdf-vm/asdf).
I think the issue #153 may also associate with this [rustup-issue](https://github.com/rust-lang/rustup/issues/988).