### PR TITLE
Upgrade Cosmos crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,8 +658,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.9.0"
-source = "git+https://github.com/crypto-com/cosmos-rust?rev=163add13d6623ea853b44b0a1596cb4430b4102a#163add13d6623ea853b44b0a1596cb4430b4102a"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60e0c62ee1728512be390ff6eb5471f674e846de06feba800c8e926583878cf0"
 dependencies = [
  "prost",
  "prost-types",
@@ -669,8 +670,9 @@ dependencies = [
 
 [[package]]
 name = "cosmrs"
-version = "0.4.1"
-source = "git+https://github.com/crypto-com/cosmos-rust?rev=163add13d6623ea853b44b0a1596cb4430b4102a#163add13d6623ea853b44b0a1596cb4430b4102a"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be4114a20b66dff0478f6c7ccb9d0c065c02718cd870aeac46d1a66f1d7f140"
 dependencies = [
  "bip32",
  "cosmos-sdk-proto",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -15,8 +15,7 @@ login = ["siwe"]
 anyhow = "1"
 bech32 = "0.8"
 bip39 = "1"
-# FIXME: Set to a release version after upgrading dependency `tendermint` in cosmos-rust (as PR https://github.com/cosmos/cosmos-rust/pull/178).
-cosmrs = { git = "https://github.com/crypto-com/cosmos-rust", rev = "163add13d6623ea853b44b0a1596cb4430b4102a" }
+cosmrs = "0.5"
 eyre = "0.6"
 # NOTE: add `features = ["legacy"]` if non-EIP-1559 network support is required
 ethers = { git = "https://github.com/gakonst/ethers-rs", rev = "de275db56a1be948cf4a543e1837f5add6f4750c" }
@@ -44,14 +43,12 @@ wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 grpc-web-client = { git = "https://github.com/titanous/grpc-web-client"}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-# FIXME: Set to a release version after upgrading dependency `tendermint` in cosmos-rust (as PR https://github.com/cosmos/cosmos-rust/pull/178).
-cosmos-sdk-proto = { git = "https://github.com/crypto-com/cosmos-rust", rev = "163add13d6623ea853b44b0a1596cb4430b4102a", default-features = false, features = ["cosmwasm"] }
+cosmos-sdk-proto = { version = "0.10", default-features = false, features = ["cosmwasm"] }
 defi-wallet-core-proto = { version = "0.1", path = "../proto" }
 tonic = { version = "0.6", default-features = false, features = ["codegen", "prost"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-# FIXME: Set to a release version after upgrading dependency `tendermint` in cosmos-rust (as PR https://github.com/cosmos/cosmos-rust/pull/178).
-cosmos-sdk-proto = { git = "https://github.com/crypto-com/cosmos-rust", rev = "163add13d6623ea853b44b0a1596cb4430b4102a", features = ["grpc"] }
+cosmos-sdk-proto = { version = "0.10", features = ["grpc"] }
 defi-wallet-core-proto = { version = "0.1", path = "../proto", features = ["transport"] }
 tokio = { version = "1", features = ["rt"] }
 tonic = { version = "0.6", default-features = false, features = ["codegen", "prost", "tls", "tls-roots", "transport"] }

--- a/common/src/transaction/cosmos_sdk.rs
+++ b/common/src/transaction/cosmos_sdk.rs
@@ -494,9 +494,7 @@ impl CosmosSDKMsg {
                     delegator_address: sender_address,
                     validator_src_address,
                     validator_dst_address,
-                    /// Amount should not be None value.
-                    /// It should be fixed after merging PR - https://github.com/cosmos/cosmos-rust/pull/175
-                    amount: Some(amount),
+                    amount,
                 };
                 msg.to_any()
             }
@@ -524,9 +522,7 @@ impl CosmosSDKMsg {
                 let msg = MsgUndelegate {
                     delegator_address: sender_address,
                     validator_address,
-                    /// Amount should not be None value.
-                    /// It should be fixed after merging PR - https://github.com/cosmos/cosmos-rust/pull/175
-                    amount: Some(amount),
+                    amount,
                 };
                 msg.to_any()
             }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -11,9 +11,8 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-# FIXME: Set to a release version after upgrading dependency `tendermint` in cosmos-rust (as PR https://github.com/cosmos/cosmos-rust/pull/178).
-cosmrs = { git = "https://github.com/crypto-com/cosmos-rust", rev = "163add13d6623ea853b44b0a1596cb4430b4102a" }
-cosmos-sdk-proto = { git = "https://github.com/crypto-com/cosmos-rust", rev = "163add13d6623ea853b44b0a1596cb4430b4102a", default-features = false }
+cosmrs = "0.5"
+cosmos-sdk-proto = { version = "0.10", default-features = false }
 prost = "0.9"
 prost-types = "0.9"
 tendermint-proto = "0.23"


### PR DESCRIPTION
Upgrade [cosmrs](https://github.com/cosmos/cosmos-rust/tree/main/cosmrs) to `0.5` and [cosmos‑sdk‑proto](https://github.com/cosmos/cosmos-rust/tree/main/cosmos-sdk-proto) to `0.10`.