### PR TITLE
 Problem: unnecessary UniFFI code in other bindings (fix #271) 

### DIFF
--- a/android_build.sh
+++ b/android_build.sh
@@ -94,9 +94,9 @@ else
         echo "x86_64 ndk installed."
 fi
 
-PATH=$PATH:`pwd`/NDK/arm64/bin cargo build --target aarch64-linux-android -p defi-wallet-core-common --release || exit 1
-PATH=$PATH:`pwd`/NDK/arm/bin cargo build --target armv7-linux-androideabi -p defi-wallet-core-common --release || exit 1
-PATH=$PATH:`pwd`/NDK/x86_64/bin cargo build --target x86_64-linux-android -p defi-wallet-core-common --release || exit 1
+PATH=$PATH:`pwd`/NDK/arm64/bin cargo build --features uniffi-binding --target aarch64-linux-android -p defi-wallet-core-common --release || exit 1
+PATH=$PATH:`pwd`/NDK/arm/bin cargo build --features uniffi-binding --target armv7-linux-androideabi -p defi-wallet-core-common --release || exit 1
+PATH=$PATH:`pwd`/NDK/x86_64/bin cargo build --features uniffi-binding --target x86_64-linux-android -p defi-wallet-core-common --release || exit 1
 
 mkdir -p mobile_modules/android_module/dwclib/libs
 cp NDK/libs/jna.aar mobile_modules/android_module/dwclib/libs/

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -13,6 +13,7 @@ default = []
 # error-prone and less security for the end user.
 abi-contract = []
 login = ["siwe"]
+uniffi-binding = ["uniffi", "uniffi_build", "uniffi_macros"]
 
 [dependencies]
 anyhow = "1"
@@ -38,8 +39,8 @@ siwe = { version = "0.2", optional = true }
 tendermint = "0.23"
 tendermint-rpc = "0.23"
 thiserror = "1"
-uniffi = "^0.17"
-uniffi_macros = "^0.17"
+uniffi = { version = "^0.17", optional = true }
+uniffi_macros = { version = "^0.17", optional = true }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 # grpc-web-client would be replaced if tonic has native grpc-web support.
 # Check https://github.com/hyperium/tonic/issues/645
@@ -57,4 +58,4 @@ tokio = { version = "1", features = ["rt"] }
 tonic = { version = "0.6", default-features = false, features = ["codegen", "prost", "tls", "tls-roots", "transport"] }
 
 [build-dependencies]
-uniffi_build = { version = "^0.17", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.17", features=["builtin-bindgen"], optional = true }

--- a/common/build.rs
+++ b/common/build.rs
@@ -1,3 +1,4 @@
 fn main() {
+    #[cfg(feature = "uniffi-binding")]
     uniffi_build::generate_scaffolding("./src/common.udl").unwrap();
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -23,7 +23,7 @@ pub use login::*;
 pub use node::*;
 pub use transaction::*;
 pub use wallet::*;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "uniffi-binding")]
 uniffi_macros::include_scaffolding!("common");
 
 #[macro_use]

--- a/common/src/transaction/cosmos_sdk.rs
+++ b/common/src/transaction/cosmos_sdk.rs
@@ -1,7 +1,5 @@
 use super::nft::*;
 use crate::SecretKey;
-#[cfg(not(target_arch = "wasm32"))]
-use crate::UniffiCustomTypeConverter;
 use cosmrs::bank::MsgSend;
 use cosmrs::bip32::secp256k1::ecdsa::SigningKey;
 use cosmrs::bip32::{PrivateKey, PublicKey, PublicKeyBytes, KEY_SIZE};
@@ -20,6 +18,11 @@ use ibc::Height;
 use ibc_proto::cosmos::base::v1beta1::Coin as IbcCoin;
 use std::str::FromStr;
 use std::sync::Arc;
+
+mod uniffi_binding;
+
+#[cfg(feature = "uniffi-binding")]
+pub use uniffi_binding::*;
 
 /// human-readable bech32 prefix for Crypto.org Chain accounts
 pub const CRYPTO_ORG_BECH32_HRP: &str = "cro";
@@ -246,22 +249,6 @@ impl From<PublicKeyBytesWrapper> for PublicKeyBytes {
         let mut result = [0u8; COMPRESSED_SECP256K1_PUBKEY_SIZE];
         result.copy_from_slice(&wrapper.0);
         result
-    }
-}
-#[cfg(not(target_arch = "wasm32"))]
-impl UniffiCustomTypeConverter for PublicKeyBytesWrapper {
-    type Builtin = Vec<u8>;
-
-    fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
-        if val.len() != COMPRESSED_SECP256K1_PUBKEY_SIZE {
-            Err(PublicKeyBytesError::InvalidLength.into())
-        } else {
-            Ok(PublicKeyBytesWrapper(val))
-        }
-    }
-
-    fn from_custom(obj: Self) -> Self::Builtin {
-        obj.0
     }
 }
 

--- a/common/src/transaction/cosmos_sdk/uniffi_binding.rs
+++ b/common/src/transaction/cosmos_sdk/uniffi_binding.rs
@@ -1,0 +1,22 @@
+#![cfg(feature = "uniffi-binding")]
+
+use crate::{
+    PublicKeyBytesError, PublicKeyBytesWrapper, UniffiCustomTypeConverter,
+    COMPRESSED_SECP256K1_PUBKEY_SIZE,
+};
+
+impl UniffiCustomTypeConverter for PublicKeyBytesWrapper {
+    type Builtin = Vec<u8>;
+
+    fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
+        if val.len() != COMPRESSED_SECP256K1_PUBKEY_SIZE {
+            Err(PublicKeyBytesError::InvalidLength.into())
+        } else {
+            Ok(PublicKeyBytesWrapper(val))
+        }
+    }
+
+    fn from_custom(obj: Self) -> Self::Builtin {
+        obj.0
+    }
+}

--- a/ios_build.sh
+++ b/ios_build.sh
@@ -8,8 +8,8 @@ fi
 
 rustup target add x86_64-apple-ios aarch64-apple-ios || exit 1
 uniffi-bindgen generate common/src/common.udl --config-path common/uniffi.toml --language swift --out-dir bindings/ios || exit 1
-cargo build --target aarch64-apple-ios -p defi-wallet-core-common --release || exit 1
-cargo build --target x86_64-apple-ios -p defi-wallet-core-common --release || exit 1
+cargo build --features uniffi-binding --target aarch64-apple-ios -p defi-wallet-core-common --release || exit 1
+cargo build --features uniffi-binding --target x86_64-apple-ios -p defi-wallet-core-common --release || exit 1
 mkdir -p mobile_modules/ios_module/dwclib/dwclib/lib.a
 lipo -create target/aarch64-apple-ios/release/libdefi_wallet_core_common.a target/x86_64-apple-ios/release/libdefi_wallet_core_common.a -output mobile_modules/ios_module/dwclib/dwclib/lib.a/libdefi_wallet_core_common.a || exit 1
 mkdir -p mobile_modules/ios_module/dwclib/dwclib/include


### PR DESCRIPTION
Close #271 

Add feature `uniffi-binding` to restrict importing UniFFI dependencies.