### PR TITLE
Problem: failed to upgrade crate ibc (from `0.12.0` to `0.13.0`) and ibc-proto (from `0.16.0` to `0.17.0`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,9 +1952,9 @@ dependencies = [
 
 [[package]]
 name = "ibc"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6530351e233b8cdd1138864542af69010a46dcc98f6582162e893750d9b551"
+checksum = "629ec09cd43235315672c61e77c02c15a14d47c2f476ca162c0ed223f579e5f9"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1979,10 +1979,11 @@ dependencies = [
 
 [[package]]
 name = "ibc-proto"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36f1d4cb572f74027104c9d49804d03c108d49b120263c9d551190ac20c3190"
+checksum = "a7c8ceb06337fcad351619eb05a045abf41a825c80014a88ce8834822fa8ccdb"
 dependencies = [
+ "base64 0.13.0",
  "bytes",
  "prost",
  "prost-types",
@@ -1992,9 +1993,9 @@ dependencies = [
 
 [[package]]
 name = "ics23"
-version = "0.6.7"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce15e4758c46a0453bdf4b3b1dfcce70c43f79d1943c2ee0635b77eb2e7aa233"
+checksum = "9d454cc0a22bd556cc3d3c69f9d75a392a36244634840697a4b9eb81bc5c8ae0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4286,9 +4287,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
+checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -4299,9 +4300,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
+checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -23,8 +23,8 @@ cosmrs = "0.5"
 eyre = "0.6"
 # NOTE: add `features = ["legacy"]` if non-EIP-1559 network support is required
 ethers = { git = "https://github.com/gakonst/ethers-rs", rev = "de275db56a1be948cf4a543e1837f5add6f4750c" }
-ibc = { version = "0.12", default-features = false }
-ibc-proto = { version = "0.16", default-features = false }
+ibc = { version = "0.13", default-features = false }
+ibc-proto = { version = "0.17", default-features = false }
 prost = "0.9"
 # NOTE: crate `bip39` cannot work with latest crate `rand` (0.8.0)
 # FIXME: https://github.com/rust-bitcoin/rust-bip39/issues/14

--- a/common/src/transaction/cosmos_sdk.rs
+++ b/common/src/transaction/cosmos_sdk.rs
@@ -538,17 +538,29 @@ impl CosmosSDKMsg {
                 token,
                 timeout_height,
                 timeout_timestamp,
-            } => Ok(MsgTransfer {
-                sender: Signer::new(sender_address),
-                receiver: Signer::new(receiver),
-                source_port: PortId::from_str(source_port)?,
-                source_channel: ChannelId::from_str(source_channel)?,
-                token: Some(token.try_into()?),
-                // TODO: timeout_height and timeout_timestamp cannot both be 0.
-                timeout_height: *timeout_height,
-                timeout_timestamp: Timestamp::from_nanoseconds(*timeout_timestamp)?,
+            } => {
+                let any = MsgTransfer {
+                    sender: Signer::new(sender_address),
+                    receiver: Signer::new(receiver),
+                    source_port: PortId::from_str(source_port)?,
+                    source_channel: ChannelId::from_str(source_channel)?,
+                    token: Some(token.try_into()?),
+                    // TODO: timeout_height and timeout_timestamp cannot both be 0.
+                    timeout_height: *timeout_height,
+                    timeout_timestamp: Timestamp::from_nanoseconds(*timeout_timestamp)?,
+                }
+                .to_any();
+                // FIXME:
+                // ibc-proto used Google's Protobuf type definitions instead of
+                // prost_types in `0.17`. But cosmrs still used prost_types. So
+                // we need to convert manually.
+                // Associate cosmos-rust issue:
+                // https://github.com/cosmos/cosmos-rust/issues/185
+                Ok(cosmrs::Any {
+                    type_url: any.type_url,
+                    value: any.value,
+                })
             }
-            .to_any()),
         }
     }
 }


### PR DESCRIPTION
Close #277 Close #8

`ibc-proto` updated to use Google's Protobuf instead of `prost_types` in [this recent PR](https://github.com/informalsystems/ibc-rs/pull/2005) (to support custom derive attributes of `Serialize` and `Deserialize`). But `cosmos-rust` still used prost_types. So we need to convert to `cosmrs::Any` manually.

I also submit [a new issue](https://github.com/cosmos/cosmos-rust/issues/185) in cosmos-rust.