### PR TITLE
Problem: missing `Cargo.lock` update (to `0.2.0`) for cpp binding (fix #349)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "defi-wallet-core-cpp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "cxx",


### PR DESCRIPTION
Close https://github.com/crypto-com/defi-wallet-core-rs/issues/349