### PR TITLE
Problem: deploy macosx version is too high (fix #411)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,16 +45,17 @@ mac_install:
 
 
 build_cpp:
-	cargo build --package defi-wallet-core-cpp --release
+	. ./checkmac.sh && cargo build --package defi-wallet-core-cpp --release
 	cd $(cpp_example) && make build
 
 cpp: build_cpp
-	. ./scripts/.env && cd $(cpp_example) && make run
+	# to fix link error on macos
+	. ./checkmac.sh && . ./scripts/.env && cd $(cpp_example) && make run
 
-cppx86_64:
-	rustup target add x86_64-apple-darwin
-	cargo build --package defi-wallet-core-cpp --release --target x86_64-apple-darwin
-	cd $(cpp_example) && make x86_64_build
+cppx86_64: 
+	. ./checkmac.sh && rustup target add x86_64-apple-darwin
+	. ./checkmac.sh && cargo build --package defi-wallet-core-cpp --release --target x86_64-apple-darwin
+	. ./checkmac.sh && cd $(cpp_example) && make x86_64_build
 
 
 proto:

--- a/checkmac.sh
+++ b/checkmac.sh
@@ -1,0 +1,9 @@
+# to fix link error on macosx
+# cd example/cpp-example
+# otool -l libcxxbridge1.a > out
+# otool -l libdefi_wallet_core_cpp.dylib > out
+# check LC_BUILD_VERSION/minos is 10.15
+if [[ $(uname) == "Darwin" ]]; then
+	export MACOSX_DEPLOYMENT_TARGET=10.15
+	echo "MACOSX_DEPLOYMENT_TARGET="$MACOSX_DEPLOYMENT_TARGET
+fi


### PR DESCRIPTION
Solution:
set MACOSX_DEPLOYMENT_TARGET to 10.15
this removes link error in ue5