### PR TITLE
Problem: missing `CosmosParser` and Terra proto in CHANGELOG (fix #413)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## [Unreleased]
 ### Added
-- Delete duplicate C-Sytle functions for Cosmos SDK in wasm binding.
 - Add polling interval argument or function for setting the polling interval on event filters and pending transactions.
 - Add `CosmosParser` to support parsing both Protobuf and Proto3 JSON mapping of standard Cosmos and `crypto.org` messages.
 - Add Terra special messages to `proto-build`.
+### Removed
+- Delete duplicate C-Sytle functions for Cosmos SDK in wasm binding.
 
 ## [0.1.12] - 2022-04-25
 ### Added


### PR DESCRIPTION
Close #413 