### PR TITLE
Problem: missing support for CMake (fix #265)

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,5 +1,4 @@
-name: Mac Build CI
-
+name: Linux Build CI
 on:
   push:
     branches:
@@ -13,8 +12,8 @@ on:
       - README.md
 
 jobs:
-  mac-build:
-    runs-on: macos-11
+  build:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths-ignore:
       - README.md
+    tags:
+      - "v*.*.*"
   pull_request:
     paths-ignore:
       - README.md

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ endif
 ifeq ($(shell uname -m), amd64)
 	rustup target add x86_64-apple-darwin
 	./checkmac.sh && cargo build --package defi-wallet-core-cpp --release --target x86_64-apple-darwin
-else
+endif
 	cd $(cpp_example) && make build
 
 cpp: build_cpp

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ ifeq ($(shell uname -m), amd64)
 	rustup target add x86_64-apple-darwin
 	./checkmac.sh && cargo build --package defi-wallet-core-cpp --release --target x86_64-apple-darwin
 endif
-	cd $(cpp_example) && make build
+	cd $(cpp_example) && make
 
 cpp: build_cpp
 	. ./scripts/.env && cd $(cpp_example) && make run

--- a/Makefile
+++ b/Makefile
@@ -43,20 +43,18 @@ mac_install:
 	brew install ktlint
 	brew install swiftformat
 
-
 build_cpp:
-# to fix link error on macos
+ifeq ($(shell uname -m), x86_64)
 	./checkmac.sh && cargo build --package defi-wallet-core-cpp --release
+endif
+ifeq ($(shell uname -m), amd64)
+	rustup target add x86_64-apple-darwin
+	./checkmac.sh && cargo build --package defi-wallet-core-cpp --release --target x86_64-apple-darwin
+else
 	cd $(cpp_example) && make build
 
 cpp: build_cpp
 	. ./scripts/.env && cd $(cpp_example) && make run
-
-cppx86_64:
-	. ./checkmac.sh && rustup target add x86_64-apple-darwin
-	. ./checkmac.sh && cargo build --package defi-wallet-core-cpp --release --target x86_64-apple-darwin
-	. ./checkmac.sh && cd $(cpp_example) && make x86_64_build
-
 
 proto:
 	cd proto-build && cargo run

--- a/Makefile
+++ b/Makefile
@@ -45,14 +45,14 @@ mac_install:
 
 
 build_cpp:
-	. ./checkmac.sh && cargo build --package defi-wallet-core-cpp --release
+# to fix link error on macos
+	./checkmac.sh && cargo build --package defi-wallet-core-cpp --release
 	cd $(cpp_example) && make build
 
 cpp: build_cpp
-	# to fix link error on macos
-	. ./checkmac.sh && . ./scripts/.env && cd $(cpp_example) && make run
+	. ./scripts/.env && cd $(cpp_example) && make run
 
-cppx86_64: 
+cppx86_64:
 	. ./checkmac.sh && rustup target add x86_64-apple-darwin
 	. ./checkmac.sh && cargo build --package defi-wallet-core-cpp --release --target x86_64-apple-darwin
 	. ./checkmac.sh && cd $(cpp_example) && make x86_64_build

--- a/checkmac.sh
+++ b/checkmac.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # to fix link error on macosx
 # cd example/cpp-example
 # otool -l libcxxbridge1.a > out

--- a/docs/cpp/Doxyfile
+++ b/docs/cpp/Doxyfile
@@ -874,9 +874,9 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../../example/cpp-example/include/rust \
-                         ../../example/cpp-example/include/defi-wallet-core-cpp/src \
-                         ../../example/cpp-example/include/ \
+INPUT                  = ../../example/cpp-example/sdk/include/rust \
+                         ../../example/cpp-example/sdk/include/defi-wallet-core-cpp/src \
+                         ../../example/cpp-example/sdk/include/ \
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/example/cpp-example/CMakeLists.txt
+++ b/example/cpp-example/CMakeLists.txt
@@ -12,7 +12,7 @@ add_subdirectory(sdk)
 # static cppexample
 add_executable(cppexamplestatic main.cc chainmain.cc cronos.cc)
 if (UNIX AND NOT APPLE)
-  target_link_libraries(cppexamplestatic PUBLIC ${DEFI_WALLET_CORE_CPP_LIB} ssl crypto)
+  target_link_libraries(cppexamplestatic PUBLIC ${DEFI_WALLET_CORE_CPP_LIB} pthread ssl crypto dl)
 else()
   target_link_libraries(cppexamplestatic PUBLIC ${DEFI_WALLET_CORE_CPP_LIB})
 endif()

--- a/example/cpp-example/CMakeLists.txt
+++ b/example/cpp-example/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.10)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQURIED ON)
+if (APPLE)
+  set(CMAKE_CXX_FLAGS "-framework Security -framework CoreFoundation")
+endif()
+if (UNIX AND NOT APPLE)
+  set(CMAKE_CXX_FLAGS "-lpthread -lssl -lcrypto -ldl")
+endif()
+
+project(cppexample VERSION 1.0)
+
+add_subdirectory(sdk)
+
+# static cppexample
+add_executable(cppexamplestatic main.cc chainmain.cc cronos.cc)
+target_link_libraries(cppexamplestatic PUBLIC ${DEFI_WALLET_CORE_CPP_LIB})
+
+# dynamic cppexample
+add_executable(cppexample main.cc chainmain.cc cronos.cc)
+target_link_libraries(cppexample PUBLIC ${RUST_LIB} ${DEFI_WALLET_CORE_CPP_DYLIB} defi_wallet_core_cpp)

--- a/example/cpp-example/CMakeLists.txt
+++ b/example/cpp-example/CMakeLists.txt
@@ -4,9 +4,6 @@ set(CMAKE_CXX_STANDARD_REQURIED ON)
 if (APPLE)
   set(CMAKE_CXX_FLAGS "-framework Security -framework CoreFoundation")
 endif()
-if (UNIX AND NOT APPLE)
-  set(CMAKE_CXX_FLAGS "-lpthread -lssl -lcrypto -ldl")
-endif()
 
 project(cppexample VERSION 1.0)
 
@@ -14,7 +11,11 @@ add_subdirectory(sdk)
 
 # static cppexample
 add_executable(cppexamplestatic main.cc chainmain.cc cronos.cc)
-target_link_libraries(cppexamplestatic PUBLIC ${DEFI_WALLET_CORE_CPP_LIB})
+if (UNIX AND NOT APPLE)
+  target_link_libraries(cppexamplestatic PUBLIC ${DEFI_WALLET_CORE_CPP_LIB} ssl crypto)
+else()
+  target_link_libraries(cppexamplestatic PUBLIC ${DEFI_WALLET_CORE_CPP_LIB})
+endif()
 
 # dynamic cppexample
 add_executable(cppexample main.cc chainmain.cc cronos.cc)

--- a/example/cpp-example/Makefile
+++ b/example/cpp-example/Makefile
@@ -20,7 +20,7 @@ ifeq ($(UNAME), Linux)
 	FLAGS=-lpthread -lssl -lcrypto -ldl
 endif
 
-all: build run
+all: clean build
 build: prepare static dynamic cmake
 run: run_static run_dynamic
 

--- a/example/cpp-example/Makefile
+++ b/example/cpp-example/Makefile
@@ -36,10 +36,10 @@ dynamic:
 		$(sdk_dir)/include/*.cc \
 		$(sdk_dir)/include/defi-wallet-core-cpp/src/*.cc \
 		$(sdk_dir)/lib/libcxxbridge1.a \
-		-ldefi_wallet_core_cpp \
 		-std=c++11 \
-		$(FLAGS)  \
-		-L $(sdk_dir)/lib \
+		-L$(sdk_dir)/lib -Wl,-rpath=$(sdk_dir)/lib -Wall \
+		-ldefi_wallet_core_cpp \
+		$(FLAGS)
 
 x86_64_static:
 	arch -x86_64 g++ -o cppexamplestatic \

--- a/example/cpp-example/Makefile
+++ b/example/cpp-example/Makefile
@@ -1,5 +1,16 @@
 UNAME := $(shell uname)
 sdk_dir = ./sdk
+ifeq ($(shell uname -m), x86_64)
+	CXX = g++
+	TARGET_DIR = ../target/release
+endif
+
+ifeq ($(shell uname -m), amd64)
+	CXX = arch -x86_64 g++
+	TARGET_DIR = ../target/x86_64-apple-darwin/release
+else
+
+endif
 
 ifeq ($(UNAME), Darwin)
 	FLAGS=-framework Security -framework CoreFoundation
@@ -14,13 +25,15 @@ build: prepare static dynamic cmake
 run: run_static run_dynamic
 
 prepare:
-	python3 helper.py --target_dir ../../target/release
+	python3 helper.py --target_dir  $(TARGET_DIR)
 
-prepare_x86_64:
-	python3 helper.py --target_dir ../../target/x86_64-apple-darwin/release
+libdefi_wallet_core_cpp.dylib:
+ifeq ($(UNAME), Darwin)
+	install_name_tool -id @rpath/libdefi_wallet_core_cpp.dylib.dylib $(sdk_dir)/lib/libdefi_wallet_core_cpp.dylib.dylib
+endif
 
 static:
-	g++ -o cppexamplestatic \
+	$(CXX) -o cppexamplestatic \
 		main.cc \
 		chainmain.cc \
 		cronos.cc \
@@ -28,8 +41,9 @@ static:
 		-std=c++11 \
 		$(FLAGS)
 
-dynamic:
-	g++ -o cppexample \
+dynamic: libdefi_wallet_core_cpp.dylib
+ifeq ($(UNAME), Linux)
+	$(CXX) -o cppexample \
 		main.cc \
 		chainmain.cc \
 		cronos.cc \
@@ -40,40 +54,30 @@ dynamic:
 		-L$(sdk_dir)/lib -Wl,-rpath=$(sdk_dir)/lib -Wall \
 		-ldefi_wallet_core_cpp \
 		$(FLAGS)
-
-x86_64_static:
-	arch -x86_64 g++ -o cppexamplestatic \
-		main.cc \
-		chainmain.cc \
-		cronos.cc \
-		$(sdk_dir)/lib/libdefi_wallet_core_cpp.a \
-		-std=c++11 \
-		$(FLAGS)
-
-x86_64_dynamic:
-	arch -x86_64 g++ -o cppexample \
+endif
+ifeq ($(UNAME), Darwin)
+	$(CXX) -o cppexample \
 		main.cc \
 		chainmain.cc \
 		cronos.cc \
 		$(sdk_dir)/include/*.cc \
 		$(sdk_dir)/include/defi-wallet-core-cpp/src/*.cc \
 		$(sdk_dir)/lib/libcxxbridge1.a \
-		-ldefi_wallet_core_cpp \
 		-std=c++11 \
-		$(FLAGS)  \
-		-L $(sdk_dir)/lib \
-
-x86_64_build: prepare_x86_64 x86_64_static x86_64_dynamic
+		$(sdk_dir)/lib/libplay_cpp_sdk.dylib \
+		-rpath $(sdk_dir)/lib \
+		$(FLAGS)
+endif
 
 cmake:
 	mkdir -p build
 	cd build && cmake .. && make
 
 run_static:
-	./cppexamplestatic
+	./cppexamplestatic && ./build/cppexamplestatic
 
 run_dynamic:
-	export LD_LIBRARY_PATH=$(PWD) && ./cppexample
+	export LD_LIBRARY_PATH=$(PWD) && ./cppexample && ./build/cppexample
 
 clean:
 	rm -f cppexample cppexamplestatic

--- a/example/cpp-example/Makefile
+++ b/example/cpp-example/Makefile
@@ -2,12 +2,12 @@ UNAME := $(shell uname)
 sdk_dir = ./sdk
 ifeq ($(shell uname -m), x86_64)
 	CXX = g++
-	TARGET_DIR = ../target/release
+	TARGET_DIR = ../../target/release
 endif
 
 ifeq ($(shell uname -m), amd64)
 	CXX = arch -x86_64 g++
-	TARGET_DIR = ../target/x86_64-apple-darwin/release
+	TARGET_DIR = ../../target/x86_64-apple-darwin/release
 else
 
 endif
@@ -29,7 +29,7 @@ prepare:
 
 libdefi_wallet_core_cpp.dylib:
 ifeq ($(UNAME), Darwin)
-	install_name_tool -id @rpath/libdefi_wallet_core_cpp.dylib.dylib $(sdk_dir)/lib/libdefi_wallet_core_cpp.dylib.dylib
+	install_name_tool -id @rpath/libdefi_wallet_core_cpp.dylib.dylib $(sdk_dir)/lib/libdefi_wallet_core_cpp.dylib
 endif
 
 static:
@@ -64,7 +64,7 @@ ifeq ($(UNAME), Darwin)
 		$(sdk_dir)/include/defi-wallet-core-cpp/src/*.cc \
 		$(sdk_dir)/lib/libcxxbridge1.a \
 		-std=c++11 \
-		$(sdk_dir)/lib/libplay_cpp_sdk.dylib \
+		$(sdk_dir)/lib/libdefi_wallet_core_cpp.dylib \
 		-rpath $(sdk_dir)/lib \
 		$(FLAGS)
 endif

--- a/example/cpp-example/Makefile
+++ b/example/cpp-example/Makefile
@@ -82,3 +82,5 @@ run_dynamic:
 clean:
 	rm -f cppexample cppexamplestatic
 	rm -rf build
+	rm -rf $(sdk_dir)/lib
+	rm -rf $(sdk_dir)/include

--- a/example/cpp-example/Makefile
+++ b/example/cpp-example/Makefile
@@ -76,5 +76,5 @@ run_dynamic:
 	export LD_LIBRARY_PATH=$(PWD) && ./cppexample
 
 clean:
-	rm cppexample cppexamplestatic
+	rm -f cppexample cppexamplestatic
 	rm -rf build

--- a/example/cpp-example/Makefile
+++ b/example/cpp-example/Makefile
@@ -1,4 +1,5 @@
 UNAME := $(shell uname)
+sdk_dir = ./sdk
 
 ifeq ($(UNAME), Darwin)
 	FLAGS=-framework Security -framework CoreFoundation
@@ -9,7 +10,7 @@ ifeq ($(UNAME), Linux)
 endif
 
 all: build run
-build: prepare static dynamic
+build: prepare static dynamic cmake
 run: run_static run_dynamic
 
 prepare:
@@ -23,7 +24,7 @@ static:
 		main.cc \
 		chainmain.cc \
 		cronos.cc \
-		lib/libdefi_wallet_core_cpp.a \
+		$(sdk_dir)/lib/libdefi_wallet_core_cpp.a \
 		-std=c++11 \
 		$(FLAGS)
 
@@ -32,20 +33,20 @@ dynamic:
 		main.cc \
 		chainmain.cc \
 		cronos.cc \
-		include/*.cc \
-		include/defi-wallet-core-cpp/src/*.cc \
-		lib/libcxxbridge1.a \
+		$(sdk_dir)/include/*.cc \
+		$(sdk_dir)/include/defi-wallet-core-cpp/src/*.cc \
+		$(sdk_dir)/lib/libcxxbridge1.a \
 		-ldefi_wallet_core_cpp \
 		-std=c++11 \
 		$(FLAGS)  \
-		-L lib \
+		-L $(sdk_dir)/lib \
 
 x86_64_static:
 	arch -x86_64 g++ -o cppexamplestatic \
 		main.cc \
 		chainmain.cc \
 		cronos.cc \
-		lib/libdefi_wallet_core_cpp.a \
+		$(sdk_dir)/lib/libdefi_wallet_core_cpp.a \
 		-std=c++11 \
 		$(FLAGS)
 
@@ -54,15 +55,19 @@ x86_64_dynamic:
 		main.cc \
 		chainmain.cc \
 		cronos.cc \
-		include/*.cc \
-		include/defi-wallet-core-cpp/src/*.cc \
-		lib/libcxxbridge1.a \
+		$(sdk_dir)/include/*.cc \
+		$(sdk_dir)/include/defi-wallet-core-cpp/src/*.cc \
+		$(sdk_dir)/lib/libcxxbridge1.a \
 		-ldefi_wallet_core_cpp \
 		-std=c++11 \
 		$(FLAGS)  \
-		-L lib \
+		-L $(sdk_dir)/lib \
 
 x86_64_build: prepare_x86_64 x86_64_static x86_64_dynamic
+
+cmake:
+	mkdir -p build
+	cd build && cmake .. && make
 
 run_static:
 	./cppexamplestatic

--- a/example/cpp-example/Makefile
+++ b/example/cpp-example/Makefile
@@ -74,3 +74,7 @@ run_static:
 
 run_dynamic:
 	export LD_LIBRARY_PATH=$(PWD) && ./cppexample
+
+clean:
+	rm cppexample cppexamplestatic
+	rm -rf build

--- a/example/cpp-example/Makefile
+++ b/example/cpp-example/Makefile
@@ -29,7 +29,7 @@ prepare:
 
 libdefi_wallet_core_cpp.dylib:
 ifeq ($(UNAME), Darwin)
-	install_name_tool -id @rpath/libdefi_wallet_core_cpp.dylib.dylib $(sdk_dir)/lib/libdefi_wallet_core_cpp.dylib
+	install_name_tool -id @rpath/libdefi_wallet_core_cpp.dylib $(sdk_dir)/lib/libdefi_wallet_core_cpp.dylib
 endif
 
 static:

--- a/example/cpp-example/chainmain.cc
+++ b/example/cpp-example/chainmain.cc
@@ -1,7 +1,7 @@
-#include "include/defi-wallet-core-cpp/src/lib.rs.h"
-#include "include/defi-wallet-core-cpp/src/nft.rs.h"
-#include "include/rust/cxx.h"
 #include "chainmain.h"
+#include "sdk/include/defi-wallet-core-cpp/src/lib.rs.h"
+#include "sdk/include/defi-wallet-core-cpp/src/nft.rs.h"
+#include "sdk/include/rust/cxx.h"
 #include <cassert>
 #include <chrono>
 #include <iostream>

--- a/example/cpp-example/cronos.cc
+++ b/example/cpp-example/cronos.cc
@@ -1,7 +1,7 @@
-#include "include/defi-wallet-core-cpp/src/contract.rs.h"
-#include "include/defi-wallet-core-cpp/src/lib.rs.h"
-#include "include/defi-wallet-core-cpp/src/uint.rs.h"
-#include "include/rust/cxx.h"
+#include "sdk/include/defi-wallet-core-cpp/src/contract.rs.h"
+#include "sdk/include/defi-wallet-core-cpp/src/lib.rs.h"
+#include "sdk/include/defi-wallet-core-cpp/src/uint.rs.h"
+#include "sdk/include/rust/cxx.h"
 #include <cassert>
 #include <chrono>
 #include <cstring>

--- a/example/cpp-example/helper.py
+++ b/example/cpp-example/helper.py
@@ -79,14 +79,15 @@ def copy_cxxbridge(output_path):
     print("Copied", OUT_DIR, "to", output_path)
 
 
-# copy library files: `*.a`, `*.dylib`, `*.dll.lib` (windows), and `*.so` (linux), to
+# copy library files: `*.a`, `*.dylib`, `*.lib` (windows), `*.dll` (windows), `*.so` (linux) to
 # `output_path`
 def copy_lib_files(output_path):
     os.makedirs(output_path, exist_ok=True)
     files = []
     files.extend(collect_files("*.a", TARGET_DIR, recursive=False))
     files.extend(collect_files("*.dylib", TARGET_DIR, recursive=False))
-    files.extend(collect_files("*.dll.lib", TARGET_DIR, recursive=False))
+    files.extend(collect_files("*.lib", TARGET_DIR, recursive=False))
+    files.extend(collect_files("*.dll", TARGET_DIR, recursive=False))
     files.extend(collect_files("*.so", TARGET_DIR, recursive=False))
     # workaround: search libcxxbridge1.a and push the first one
     files.append(collect_files("libcxxbridge1.a", TARGET_DIR)[0])

--- a/example/cpp-example/helper.py
+++ b/example/cpp-example/helper.py
@@ -79,13 +79,15 @@ def copy_cxxbridge(output_path):
     print("Copied", OUT_DIR, "to", output_path)
 
 
-# copy library files: `*.a`, `*.dylib`, and `*.dll.lib` (windows) to `output_path`
+# copy library files: `*.a`, `*.dylib`, `*.dll.lib` (windows), and `*.so` (linux), to
+# `output_path`
 def copy_lib_files(output_path):
     os.makedirs(output_path, exist_ok=True)
     files = []
     files.extend(collect_files("*.a", TARGET_DIR, recursive=False))
     files.extend(collect_files("*.dylib", TARGET_DIR, recursive=False))
     files.extend(collect_files("*.dll.lib", TARGET_DIR, recursive=False))
+    files.extend(collect_files("*.so", TARGET_DIR, recursive=False))
     # workaround: search libcxxbridge1.a and push the first one
     files.append(collect_files("libcxxbridge1.a", TARGET_DIR)[0])
 

--- a/example/cpp-example/helper.py
+++ b/example/cpp-example/helper.py
@@ -20,8 +20,8 @@ SOURCES = [
 CPP_EXAMPLE_PATH = Path(__file__).parent
 VS_EXAMPLE_PATH = Path(__file__).parent.parent / "vs-example/vs-example"
 
-INCLUDE_PATH = "include"
-LIB_PATH = "lib"
+INCLUDE_PATH = "sdk/include"
+LIB_PATH = "sdk/lib"
 
 INITIAL_INCLUDES = [
     '#include "defi-wallet-core-cpp/src/lib.rs.h"',
@@ -76,6 +76,7 @@ def copy_cxxbridge(output_path):
 
     # copy the bindings, need python 3.8+
     shutil.copytree(OUT_DIR, output_path, dirs_exist_ok=True)
+    print("Copied", OUT_DIR, "to", output_path)
 
 
 # copy library files: `*.a`, `*.dylib`, and `*.dll.lib` (windows) to `output_path`
@@ -91,6 +92,7 @@ def copy_lib_files(output_path):
     # copy the libraries, need python 3.8+
     for f in files:
         shutil.copy(f, output_path)
+        print("Copied", f, "to", output_path)
 
 
 # copy `EXAMPLE_SOURCES` to `output_path`

--- a/example/cpp-example/helper.py
+++ b/example/cpp-example/helper.py
@@ -79,8 +79,8 @@ def copy_cxxbridge(output_path):
     print("Copied", OUT_DIR, "to", output_path)
 
 
-# copy library files: `*.a`, `*.dylib`, `*.lib` (windows), `*.dll` (windows), `*.so` (linux) to
-# `output_path`
+# copy library files: `*.a`, `*.dylib`, `*.lib` (windows), `*.dll` (windows), `*.so`
+# (linux) to `output_path`
 def copy_lib_files(output_path):
     os.makedirs(output_path, exist_ok=True)
     files = []

--- a/example/cpp-example/main.cc
+++ b/example/cpp-example/main.cc
@@ -1,8 +1,8 @@
-#include "include/defi-wallet-core-cpp/src/lib.rs.h"
-#include "include/defi-wallet-core-cpp/src/nft.rs.h"
-#include "include/rust/cxx.h"
 #include "chainmain.h"
 #include "cronos.h"
+#include "sdk/include/defi-wallet-core-cpp/src/lib.rs.h"
+#include "sdk/include/defi-wallet-core-cpp/src/nft.rs.h"
+#include "sdk/include/rust/cxx.h"
 #include <atomic>
 #include <cassert>
 #include <chrono>
@@ -13,17 +13,17 @@
 #include <thread>
 
 int main(int argc, char *argv[]) {
-    try {
-        chainmain_process();   // chain-main
-        test_chainmain_nft();  // chainmain nft tests
-        test_login();          // decentralized login
-        cronos_process();      // cronos
-        test_cronos_testnet(); // cronos testnet
-    } catch (const rust::cxxbridge1::Error &e) {
-        // Use `Assertion failed`, the same as `assert` function
-        std::cout << "Assertion failed: " << e.what() << std::endl;
-    }
+  try {
+    chainmain_process();   // chain-main
+    test_chainmain_nft();  // chainmain nft tests
+    test_login();          // decentralized login
+    cronos_process();      // cronos
+    test_cronos_testnet(); // cronos testnet
+  } catch (const rust::cxxbridge1::Error &e) {
+    // Use `Assertion failed`, the same as `assert` function
+    std::cout << "Assertion failed: " << e.what() << std::endl;
+  }
 
-    test_interval();
-    return 0;
+  test_interval();
+  return 0;
 }

--- a/example/cpp-example/sdk/CMakeLists.txt
+++ b/example/cpp-example/sdk/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQURIED ON)
 
-project(defi_wallet_core_cpp VERSION 0.0.1)
+project(defi_wallet_core_cpp VERSION 0.2.0)
 
 # Find bindings source files
 file(GLOB_RECURSE DEFI_WALLET_CORE_CPP_BINDINGS include/defi-wallet-core-cpp/src/*.cc)

--- a/example/cpp-example/sdk/CMakeLists.txt
+++ b/example/cpp-example/sdk/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.10)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQURIED ON)
+
+project(defi_wallet_core_cpp VERSION 0.0.1)
+
+# Find bindings source files
+file(GLOB_RECURSE DEFI_WALLET_CORE_CPP_BINDINGS include/defi-wallet-core-cpp/src/*.cc)
+file(GLOB DEFI_WALLET_CORE_CPP_SROUCES include/*.cc)
+
+# Find the rust types binding library
+find_library(RUST_LIB libcxxbridge1.a REQUIRED PATHS ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+
+# Find the prebuilt static and dynamic libraries
+if (WIN32)
+  find_library(DEFI_WALLET_CORE_CPP_LIB defi_wallet_core_cpp.lib PATHS ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+  find_library(DEFI_WALLET_CORE_CPP_DYLIB defi_wallet_core_cpp.dll.lib PATHS ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+endif()
+
+if (APPLE)
+  find_library(DEFI_WALLET_CORE_CPP_LIB libdefi_wallet_core_cpp.a PATHS ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+  find_library(DEFI_WALLET_CORE_CPP_DYLIB libdefi_wallet_core_cpp.dylib PATHS ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+endif()
+
+if (UNIX AND NOT APPLE)
+  find_library(DEFI_WALLET_CORE_CPP_LIB libdefi_wallet_core_cpp.a PATHS ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+  find_library(DEFI_WALLET_CORE_CPP_DYLIB libdefi_wallet_core_cpp.so PATHS ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+endif()
+
+# Add library defi_wallet_core_cpp built from bindings source files
+add_library(defi_wallet_core_cpp ${DEFI_WALLET_CORE_CPP_BINDINGS} ${DEFI_WALLET_CORE_CPP_SROUCES})

--- a/example/vs-example/vs-example/vs-example.vcxproj
+++ b/example/vs-example/vs-example/vs-example.vcxproj
@@ -142,16 +142,13 @@
     <ClCompile Include="cronos.cc" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="bindings.h" />
-  </ItemGroup>
-  <ItemGroup>
-    <Library Include="lib\defi_wallet_core_cpp.dll.lib" />
-    <Library Include="lib\libcxxbridge1.a" />
-    <ClCompile Include="include\nft.cc" />
-    <ClCompile Include="include\defi-wallet-core-cpp\src\lib.rs.cc" />
-    <ClCompile Include="include\defi-wallet-core-cpp\src\nft.rs.cc" />
-    <ClCompile Include="include\defi-wallet-core-cpp\src\contract.rs.cc" />
-    <ClCompile Include="include\defi-wallet-core-cpp\src\uint.rs.cc" />
+    <Library Include="sdk\lib\defi_wallet_core_cpp.dll.lib" />
+    <Library Include="sdk\lib\libcxxbridge1.a" />
+    <ClCompile Include="sdk\include\nft.cc" />
+    <ClCompile Include="sdk\include\defi-wallet-core-cpp\src\lib.rs.cc" />
+    <ClCompile Include="sdk\include\defi-wallet-core-cpp\src\nft.rs.cc" />
+    <ClCompile Include="sdk\include\defi-wallet-core-cpp\src\contract.rs.cc" />
+    <ClCompile Include="sdk\include\defi-wallet-core-cpp\src\uint.rs.cc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />


### PR DESCRIPTION
Solution:
- Add basic cmake support and test cmake in CI
- Move the libraries and bindings to sdk
- Integrate x86_64 and amd64 in Makefile
- Add linux_build.yml
- Use rpath for mac dynamic library
- Use so file for linux dynamic library
- Simplify the process of build example by one `make`


👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [x] Have you read the [CONTRIBUTING.md](https://github.com/crypto-com/defi-wallet-core-rs/blob/main/CONTRIBUTING.md)?
- [x] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [x] Have you rebased your work on top of the latest main? 
- [ ] Have you checked your code compiles? (`cargo build`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`cargo test`)
- [ ] Have you checked your code formatting is correct? (`cargo fmt -- --check --color=auto`)
- [ ] Have you checked your basic code style is fine? (`cargo clippy`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`cargo audit`)
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-com/defi-wallet-core-rs/blob/main/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-com/defi-wallet-core-rs/blob/main/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-com/defi-wallet-core-rs/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Thank you for your code, it's appreciated! :)
