### PR TITLE
Problem: missing Python bindings support (fixes #509)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ uniffi-bindgen generate common/src/common.udl --config common/uniffi.toml --lang
 wasm-pack build --scope crypto-com bindings/wasm
 ```
 
+### Python
+```bash
+uniffi-bindgen generate common/src/common.udl --config common/uniffi.toml --language python --out-dir bindings/python
+```
+
 ## Building
 
 ## Building Proto files from source

--- a/common/uniffi.toml
+++ b/common/uniffi.toml
@@ -6,3 +6,6 @@ cdylib_name = "dwc-common"
 ffi_module_name = "DefiWalletCore"
 ffi_module_filename = "dwc_commonFFI"
 generate_module_map = false
+
+[bindings.python]
+cdylib_name = "defi_wallet_core_common"


### PR DESCRIPTION
Solution:
added a basic config to the UniFFI, so that the generated bindings
expect a dynamic library similar to what setuptools expect/build
