### PR TITLE
Problem: missing a choice of transaction broadcast modes (fixes #513)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Added
 - Add denomination query support to UniFFI bindings
 
+### Changed
+- Extend UniFFI broadcast transaction binding to take an optional argument to specify the broadcast mode
+
 ## [0.2.1] - 2022-07-18
 ### Added
 - Add CMake Support

--- a/common/src/common.udl
+++ b/common/src/common.udl
@@ -226,6 +226,13 @@ dictionary TxBroadcastResult {
     string log;
 };
 
+[Enum]
+interface TxBroadcastMode {
+    Sync();
+    Async();
+    Commit();
+};
+
 dictionary DenomMetadata {
     string base;
     string name;
@@ -239,7 +246,7 @@ interface CosmosSDKClient {
     constructor(string tendermint_rpc_url, string rest_api_url, BalanceApiVersion balance_api_version, string grpc_url);
 
     [Throws=RestError]
-    TxBroadcastResult broadcast_tx(sequence<u8> raw_signed_tx);
+    TxBroadcastResult broadcast_tx(sequence<u8> raw_signed_tx, TxBroadcastMode? mode);
 
     [Throws=RestError]
     RawRpcBalance get_account_balance([ByRef] string address, [ByRef] string denom);


### PR DESCRIPTION
Solution: extended the UniFFI binding to take a choice of transaction
broadcast modes
