### PR TITLE
Problem: cannot get backup-mnemonics from existing wallet in c++ bind…

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -44,6 +44,9 @@ jobs:
             ${{ runner.os }}-gradle-
       - run: make install-uniffi-bindgen
       - run: |
+          export ANDROID_HOME=$HOME/Library/Android/sdk
+          export SDKMANAGER=$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager
+          echo y | $SDKMANAGER "ndk;21.4.7075529"
           export NDK_HOME=/Users/runner/Library/Android/sdk/ndk/21.4.7075529
           export JAVA_HOME=$JAVA_HOME_11_X64
           make android

--- a/bindings/cpp/src/lib.rs
+++ b/bindings/cpp/src/lib.rs
@@ -435,6 +435,12 @@ pub mod ffi {
         /// generates the HD wallet with a BIP39 backup phrase (English words) and password
         fn new_wallet(password: String, word_count: MnemonicWordCount) -> Result<Box<Wallet>>;
 
+        /// get backup mnemonic phrase
+        fn get_backup_mnemonic_phrase(self: &Wallet) -> Result<String>;
+
+        /// generate mnemonics
+        fn generate_mnemonics(password: String, word_count: MnemonicWordCount) -> Result<String>;
+
         /// recovers/imports HD wallet from a BIP39 backup phrase (English words) and password
         fn restore_wallet(mnemonic: String, password: String) -> Result<Box<Wallet>>;
         /// returns the default address of the wallet
@@ -694,6 +700,14 @@ fn new_wallet(password: String, word_count: MnemonicWordCount) -> Result<Box<Wal
     Ok(Box::new(Wallet { wallet }))
 }
 
+/// generate mnemonics
+fn generate_mnemonics(password: String, word_count: MnemonicWordCount) -> Result<String> {
+    let wallet = HDWallet::generate_wallet(Some(password), Some(word_count.into()))?;
+    wallet
+        .get_backup_mnemonic_phrase()
+        .ok_or_else(|| anyhow!("Cannot generate new mnemonics"))
+}
+
 /// recovers/imports HD wallet from a BIP39 backup phrase (English words) and password
 fn restore_wallet(mnemonic: String, password: String) -> Result<Box<Wallet>> {
     let wallet = HDWallet::recover_wallet(mnemonic, Some(password))?;
@@ -701,6 +715,13 @@ fn restore_wallet(mnemonic: String, password: String) -> Result<Box<Wallet>> {
 }
 
 impl Wallet {
+    /// get backup mnemonic phrase
+    fn get_backup_mnemonic_phrase(self: &Wallet) -> Result<String> {
+        self.wallet
+            .get_backup_mnemonic_phrase()
+            .ok_or_else(|| anyhow!("No backup mnemonic phrase"))
+    }
+
     /// returns the default address of the wallet
     pub fn get_default_address(&self, coin: CoinType) -> Result<String> {
         self.get_address(coin, 0)

--- a/example/cpp-example/CMakeLists.txt
+++ b/example/cpp-example/CMakeLists.txt
@@ -11,7 +11,7 @@ project(cppexample VERSION 1.0)
 add_subdirectory(sdk)
 
 # static cppexample
-add_executable(cppexamplestatic main.cc chainmain.cc cronos.cc)
+add_executable(cppexamplestatic main.cc chainmain.cc cronos.cc wallet.cc)
 if (UNIX AND NOT APPLE)
   target_link_libraries(cppexamplestatic PUBLIC ${DEFI_WALLET_CORE_CPP_LIB} pthread dl)
 else()
@@ -19,5 +19,5 @@ else()
 endif()
 
 # dynamic cppexample
-add_executable(cppexample main.cc chainmain.cc cronos.cc)
+add_executable(cppexample main.cc chainmain.cc cronos.cc wallet.cc)
 target_link_libraries(cppexample PUBLIC ${RUST_LIB} ${DEFI_WALLET_CORE_CPP_DYLIB} defi_wallet_core_cpp)

--- a/example/cpp-example/Makefile
+++ b/example/cpp-example/Makefile
@@ -39,6 +39,7 @@ static:
 		main.cc \
 		chainmain.cc \
 		cronos.cc \
+		wallet.cc \
 		$(sdk_dir)/lib/libdefi_wallet_core_cpp.a \
 		-std=c++11 \
 		$(FLAGS)
@@ -48,6 +49,7 @@ ifeq ($(UNAME), Linux)
 	$(CXX) -o cppexample \
 		main.cc \
 		chainmain.cc \
+		wallet.cc \
 		cronos.cc \
 		$(sdk_dir)/include/*.cc \
 		$(sdk_dir)/include/defi-wallet-core-cpp/src/*.cc \
@@ -61,6 +63,7 @@ ifeq ($(UNAME), Darwin)
 	$(CXX) -o cppexample \
 		main.cc \
 		chainmain.cc \
+		wallet.cc \
 		cronos.cc \
 		$(sdk_dir)/include/*.cc \
 		$(sdk_dir)/include/defi-wallet-core-cpp/src/*.cc \

--- a/example/cpp-example/helper.py
+++ b/example/cpp-example/helper.py
@@ -10,6 +10,8 @@ EXAMPLE_SOURCES = [
     "cronos.cc",
     "chainmain.h",
     "cronos.h",
+    "wallet.cc",
+    "wallet.h",
 ]
 
 SOURCES = [

--- a/example/cpp-example/main.cc
+++ b/example/cpp-example/main.cc
@@ -1,5 +1,6 @@
 #include "chainmain.h"
 #include "cronos.h"
+#include "wallet.h"
 #include "sdk/include/defi-wallet-core-cpp/src/lib.rs.h"
 #include "sdk/include/defi-wallet-core-cpp/src/nft.rs.h"
 #include "sdk/include/rust/cxx.h"
@@ -15,6 +16,7 @@
 int main(int argc, char *argv[]) {
   try {
     org::defi_wallet_core::set_cronos_httpagent("cronos-wallet-cpp-example");
+    test_wallet();
     chainmain_process();   // chain-main
     test_chainmain_nft();  // chainmain nft tests
     test_login();          // decentralized login

--- a/example/cpp-example/wallet.cc
+++ b/example/cpp-example/wallet.cc
@@ -1,0 +1,46 @@
+#include "sdk/include/defi-wallet-core-cpp/src/contract.rs.h"
+#include "sdk/include/defi-wallet-core-cpp/src/lib.rs.h"
+#include "sdk/include/defi-wallet-core-cpp/src/uint.rs.h"
+#include "sdk/include/rust/cxx.h"
+#include <cassert>
+#include <chrono>
+#include <cstring>
+#include <iostream>
+
+using namespace std;
+using namespace org::defi_wallet_core;
+using namespace rust;
+String getEnv(String key);
+void test_wallet_restore(String password) {
+  rust::String mymnemonics = getEnv("SIGNER1_MNEMONIC");
+  int index = 0;
+  Box<Wallet> mywallet = restore_wallet(mymnemonics, "");
+  rust::String backupmnemonics = mywallet->get_backup_mnemonic_phrase();
+  assert(mymnemonics == backupmnemonics);
+}
+
+void test_wallet_generatemnemonics(String passowrd) {
+  rust::String mymnemonics =
+      generate_mnemonics("", MnemonicWordCount::TwentyFour);
+  int index = 0;
+  Box<Wallet> mywallet = restore_wallet(mymnemonics, "");
+  rust::String backupmnemonics = mywallet->get_backup_mnemonic_phrase();
+  assert(mymnemonics == backupmnemonics);
+}
+void test_wallet_new(String password) {
+  Box<Wallet> mywallet = new_wallet("", MnemonicWordCount::Twelve);
+  int index = 0;
+  rust::String mymnemonics = mywallet->get_backup_mnemonic_phrase();
+
+  Box<Wallet> mywallet2 = restore_wallet(mymnemonics, "");
+  rust::String backupmnemonics = mywallet2->get_backup_mnemonic_phrase();
+  assert(mymnemonics == backupmnemonics);
+}
+void test_wallet() {
+  test_wallet_restore(String(""));
+  test_wallet_generatemnemonics(String(""));
+  test_wallet_new(String(""));
+  test_wallet_restore(String("mypassword"));
+  test_wallet_generatemnemonics(String("mypassword"));
+  test_wallet_new(String("mypassword"));
+}

--- a/example/cpp-example/wallet.h
+++ b/example/cpp-example/wallet.h
@@ -1,0 +1,1 @@
+void test_wallet();

--- a/example/vs-example/vs-example/vs-example.vcxproj
+++ b/example/vs-example/vs-example/vs-example.vcxproj
@@ -140,6 +140,7 @@
     <ClCompile Include="main.cc" />
     <ClCompile Include="chainmain.cc" />
     <ClCompile Include="cronos.cc" />
+    <ClCompile Include="wallet.cc" />
   </ItemGroup>
   <ItemGroup>
     <Library Include="sdk\lib\defi_wallet_core_cpp.dll.lib" />


### PR DESCRIPTION
Problem: cannot get backup-mnemonics from existing wallet in c++ binding (fix #541)

Solution: add get-backup-mnemonics
