### PR TITLE
Problem: tight coupling between cronos apis and privatekey (fixes #453)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c794e162a5eff65c72ef524dfe393eb923c354e350bb78b9c7383df13f3bc142"
+checksum = "508b352bb5c066aac251f6daf6b36eccd03e8a88e8081cd44959ea277a3af9a8"
 
 [[package]]
 name = "arrayvec"

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::derive_partial_eq_without_eq)] // FIXME: derive `Eq` on types
+
 /// Eth contract types generated from ABI
 pub mod contract;
 /// interactions with remote node RPC / API (querying, broadcast etc.)

--- a/common/src/transaction/cosmos_sdk.rs
+++ b/common/src/transaction/cosmos_sdk.rs
@@ -590,7 +590,7 @@ impl CosmosSDKMsg {
                 timeout_timestamp,
             } => {
                 let any = MsgTransfer {
-                    sender: Signer::from_str(&sender_address.to_string())?,
+                    sender: Signer::from_str(sender_address.as_ref())?,
                     receiver: Signer::from_str(receiver)?,
                     source_port: PortId::from_str(source_port)?,
                     source_channel: ChannelId::from_str(source_channel)?,

--- a/common/src/transaction/ethereum/error.rs
+++ b/common/src/transaction/ethereum/error.rs
@@ -1,10 +1,7 @@
 use ethers::abi::ethereum_types::{FromDecStrErr, FromStrRadixErr};
-use ethers::contract::ContractError;
 use ethers::core::k256::ecdsa::SigningKey;
 use ethers::middleware::signer::SignerMiddlewareError;
-use ethers::prelude::{
-    abi, Http, ParseChainError, Provider, ProviderError, SignerMiddleware, Wallet,
-};
+use ethers::prelude::{abi, Http, ParseChainError, Provider, ProviderError, Wallet};
 use ethers::types::transaction::eip712;
 use ethers::utils::ConversionError;
 
@@ -38,9 +35,9 @@ pub enum EthError {
     #[error("Async Runtime error")]
     AsyncRuntimeError,
     #[error("Contract Send Error: {0}")]
-    ContractSendError(ContractError<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>),
+    ContractSendError(String),
     #[error("Contract Call Error: {0}")]
-    ContractCallError(ContractError<Provider<Http>>),
+    ContractCallError(String),
     #[error("Signature error")]
     SignatureError,
     #[error("Chainid error: {0}")]

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_import_braces)]
+#![allow(clippy::derive_partial_eq_without_eq)] // FIXME: generate types with `Eq`
 
 use cosmos_sdk_proto::cosmos;
 pub use tendermint_proto as tendermint;


### PR DESCRIPTION
Solution: made the contract-related functionality work on any `Middleware`
instead of the fixed wallet signer; added a method
to get the transaction request
