### PR TITLE
Problem: Android ci failed with network (fix #578)

### DIFF
--- a/mobile_modules/android_module/dwclib/src/androidTest/java/com/crypto/dwclib/ExampleInstrumentedTest.kt
+++ b/mobile_modules/android_module/dwclib/src/androidTest/java/com/crypto/dwclib/ExampleInstrumentedTest.kt
@@ -657,16 +657,15 @@ class ExampleInstrumentedTest {
         Assert.assertEquals(txBody, txBodyBuild)
     }
 
-//    @Test
-//    fun getAccountBalanceWorkTest() {
-//        val rb = getAccountBalanceBlocking(
-//            "https://mainnet.crypto.org:1317",
-//            "cro1yjjlx5qsrj5rxn5xtd5rkm6dcqzlchxkrvsmg6",
-//            "basecro",
-//            BalanceApiVersion.NEW
-//        )
-//        println("Balance:" + rb)
-//    }
+    fun getAccountBalanceWorkTest() {
+        val rb = getAccountBalanceBlocking(
+            "https://mainnet.crypto.org:1317",
+            "cro1yjjlx5qsrj5rxn5xtd5rkm6dcqzlchxkrvsmg6",
+            "basecro",
+            BalanceApiVersion.NEW
+        )
+        println("Balance:" + rb)
+    }
 
 
 }

--- a/mobile_modules/android_module/dwclib/src/androidTest/java/com/crypto/dwclib/ExampleInstrumentedTest.kt
+++ b/mobile_modules/android_module/dwclib/src/androidTest/java/com/crypto/dwclib/ExampleInstrumentedTest.kt
@@ -657,16 +657,16 @@ class ExampleInstrumentedTest {
         Assert.assertEquals(txBody, txBodyBuild)
     }
 
-    @Test
-    fun getAccountBalanceWorkTest() {
-        val rb = getAccountBalanceBlocking(
-            "https://mainnet.crypto.org:1317",
-            "cro1yjjlx5qsrj5rxn5xtd5rkm6dcqzlchxkrvsmg6",
-            "basecro",
-            BalanceApiVersion.NEW
-        )
-        println("Balance:" + rb)
-    }
+//    @Test
+//    fun getAccountBalanceWorkTest() {
+//        val rb = getAccountBalanceBlocking(
+//            "https://mainnet.crypto.org:1317",
+//            "cro1yjjlx5qsrj5rxn5xtd5rkm6dcqzlchxkrvsmg6",
+//            "basecro",
+//            BalanceApiVersion.NEW
+//        )
+//        println("Balance:" + rb)
+//    }
 
 
 }


### PR DESCRIPTION
Disable getAccountBalanceWorkTest test case in android, to avoid CI failures due to network issues.