### PR TITLE
Problem: clippy fails for wasm-bindgen-related crate upgrades (fixes #597)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,6 +1087,7 @@ dependencies = [
  "js-sys",
  "reqwest",
  "serde",
+ "serde-wasm-bindgen",
  "tendermint",
  "tendermint-rpc",
  "tonic-web-wasm-client",
@@ -2283,9 +2284,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3702,6 +3703,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfc62771e7b829b517cb213419236475f434fb480eddd76112ae182d274434a"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4798,9 +4810,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if",
  "serde",
@@ -4810,9 +4822,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
  "log",
@@ -4825,9 +4837,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4837,9 +4849,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4847,9 +4859,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4860,15 +4872,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513df541345bb9fcc07417775f3d51bbb677daf307d8035c0afafd87dc2e6599"
+checksum = "09d2fff962180c3fadf677438054b1db62bee4aa32af26a45388af07d1287e1d"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -4880,9 +4892,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6150d36a03e90a3cf6c12650be10626a9902d70c5270fd47d7a47e5389a10d56"
+checksum = "4683da3dfc016f704c9f82cf401520c4f1cb3ee440f7f52b3d6ac29506a49ca7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -21,8 +21,9 @@ cronos-test = []
 defi-wallet-core-common = { path = "../../common", features = ["abi-contract"] }
 js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
+serde-wasm-bindgen = "0.4"
 wasm-bindgen-futures = "0.4"
-wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
+wasm-bindgen = "0.2"
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for

--- a/bindings/wasm/src/cosmos_sdk.rs
+++ b/bindings/wasm/src/cosmos_sdk.rs
@@ -47,7 +47,7 @@ impl CosmosClient {
             };
             let account_details =
                 get_account_balance(&api_url, &address, &denom, api_version).await?;
-            JsValue::from_serde(&account_details).map_err(format_to_js_error)
+            serde_wasm_bindgen::to_value(&account_details).map_err(format_to_js_error)
         })
     }
 
@@ -57,7 +57,7 @@ impl CosmosClient {
         let api_url = self.config.api_url.to_owned();
         future_to_promise(async move {
             let account_details = get_account_details(&api_url, &address).await?;
-            JsValue::from_serde(&account_details).map_err(format_to_js_error)
+            serde_wasm_bindgen::to_value(&account_details).map_err(format_to_js_error)
         })
     }
 
@@ -72,10 +72,10 @@ impl CosmosClient {
                 .map_err(format_to_js_error)?;
 
             if let tendermint::abci::Code::Err(_) = resp.code {
-                return Err(JsValue::from_serde(&resp).map_err(format_to_js_error)?);
+                return Err(serde_wasm_bindgen::to_value(&resp).map_err(format_to_js_error)?);
             }
 
-            JsValue::from_serde(&resp).map_err(format_to_js_error)
+            serde_wasm_bindgen::to_value(&resp).map_err(format_to_js_error)
         })
     }
 }
@@ -419,7 +419,7 @@ impl GrpcWebClient {
     }
     pub async fn supply(&mut self, denom_id: String, owner: String) -> Result<JsValue, JsValue> {
         let supply = self.0.supply(denom_id, owner).await?;
-        JsValue::from_serde(&supply).map_err(format_to_js_error)
+        serde_wasm_bindgen::to_value(&supply).map_err(format_to_js_error)
     }
 
     pub async fn owner(
@@ -429,7 +429,7 @@ impl GrpcWebClient {
         pagination: Option<PageRequest>,
     ) -> Result<JsValue, JsValue> {
         let owner = self.0.owner(denom_id, owner, pagination).await?;
-        JsValue::from_serde(&owner).map_err(format_to_js_error)
+        serde_wasm_bindgen::to_value(&owner).map_err(format_to_js_error)
     }
 
     pub async fn collection(
@@ -438,26 +438,26 @@ impl GrpcWebClient {
         pagination: Option<PageRequest>,
     ) -> Result<JsValue, JsValue> {
         let collection = self.0.collection(denom_id, pagination).await?;
-        JsValue::from_serde(&collection).map_err(format_to_js_error)
+        serde_wasm_bindgen::to_value(&collection).map_err(format_to_js_error)
     }
 
     pub async fn denom(&mut self, denom_id: String) -> Result<JsValue, JsValue> {
         let denom = self.0.denom(denom_id).await?;
-        JsValue::from_serde(&denom).map_err(format_to_js_error)
+        serde_wasm_bindgen::to_value(&denom).map_err(format_to_js_error)
     }
 
     pub async fn denom_by_name(&mut self, denom_name: String) -> Result<JsValue, JsValue> {
         let denom = self.0.denom_by_name(denom_name).await?;
-        JsValue::from_serde(&denom).map_err(format_to_js_error)
+        serde_wasm_bindgen::to_value(&denom).map_err(format_to_js_error)
     }
 
     pub async fn denoms(&mut self, pagination: Option<PageRequest>) -> Result<JsValue, JsValue> {
         let denoms = self.0.denoms(pagination).await?;
-        JsValue::from_serde(&denoms).map_err(format_to_js_error)
+        serde_wasm_bindgen::to_value(&denoms).map_err(format_to_js_error)
     }
 
     pub async fn nft(&mut self, denom_id: String, token_id: String) -> Result<JsValue, JsValue> {
         let nft = self.0.nft(denom_id, token_id).await?;
-        JsValue::from_serde(&nft).map_err(format_to_js_error)
+        serde_wasm_bindgen::to_value(&nft).map_err(format_to_js_error)
     }
 }

--- a/bindings/wasm/src/ethereum.rs
+++ b/bindings/wasm/src/ethereum.rs
@@ -58,12 +58,12 @@ impl EthContractFunctionArg {
     #[wasm_bindgen]
     pub fn build_address(address_str: &str) -> Result<JsValue, JsValue> {
         let token = EthAbiToken::from_address_str(address_str)?;
-        JsValue::from_serde(&Self { token }).map_err(format_to_js_error)
+        serde_wasm_bindgen::to_value(&Self { token }).map_err(format_to_js_error)
     }
 
     #[wasm_bindgen]
     pub fn build_fixed_bytes(bytes: Vec<u8>) -> Result<JsValue, JsValue> {
-        JsValue::from_serde(&Self {
+        serde_wasm_bindgen::to_value(&Self {
             token: EthAbiToken::FixedBytes(bytes),
         })
         .map_err(format_to_js_error)
@@ -71,7 +71,7 @@ impl EthContractFunctionArg {
 
     #[wasm_bindgen]
     pub fn build_bytes(bytes: Vec<u8>) -> Result<JsValue, JsValue> {
-        JsValue::from_serde(&Self {
+        serde_wasm_bindgen::to_value(&Self {
             token: EthAbiToken::Bytes(bytes),
         })
         .map_err(format_to_js_error)
@@ -80,18 +80,18 @@ impl EthContractFunctionArg {
     #[wasm_bindgen]
     pub fn build_int(int_str: &str) -> Result<JsValue, JsValue> {
         let token = EthAbiToken::from_int_str(int_str)?;
-        JsValue::from_serde(&Self { token }).map_err(format_to_js_error)
+        serde_wasm_bindgen::to_value(&Self { token }).map_err(format_to_js_error)
     }
 
     #[wasm_bindgen]
     pub fn build_uint(uint_str: &str) -> Result<JsValue, JsValue> {
         let token = EthAbiToken::from_uint_str(uint_str)?;
-        JsValue::from_serde(&Self { token }).map_err(format_to_js_error)
+        serde_wasm_bindgen::to_value(&Self { token }).map_err(format_to_js_error)
     }
 
     #[wasm_bindgen]
     pub fn build_bool(value: bool) -> Result<JsValue, JsValue> {
-        JsValue::from_serde(&Self {
+        serde_wasm_bindgen::to_value(&Self {
             token: EthAbiToken::Bool(value),
         })
         .map_err(format_to_js_error)
@@ -99,7 +99,7 @@ impl EthContractFunctionArg {
 
     #[wasm_bindgen]
     pub fn build_string(value: String) -> Result<JsValue, JsValue> {
-        JsValue::from_serde(&Self {
+        serde_wasm_bindgen::to_value(&Self {
             token: EthAbiToken::String(value),
         })
         .map_err(format_to_js_error)
@@ -111,7 +111,7 @@ impl EthContractFunctionArg {
             .into_iter()
             .map(|val| val.try_into().map(|arg: EthContractFunctionArg| arg.token))
             .collect::<Result<Vec<EthAbiToken>, _>>()?;
-        JsValue::from_serde(&Self {
+        serde_wasm_bindgen::to_value(&Self {
             token: EthAbiToken::FixedArray(tokens),
         })
         .map_err(format_to_js_error)
@@ -123,7 +123,7 @@ impl EthContractFunctionArg {
             .into_iter()
             .map(|val| val.try_into().map(|arg: EthContractFunctionArg| arg.token))
             .collect::<Result<Vec<EthAbiToken>, _>>()?;
-        JsValue::from_serde(&Self {
+        serde_wasm_bindgen::to_value(&Self {
             token: EthAbiToken::Array(tokens),
         })
         .map_err(format_to_js_error)
@@ -135,7 +135,7 @@ impl EthContractFunctionArg {
             .into_iter()
             .map(|val| val.try_into().map(|arg: EthContractFunctionArg| arg.token))
             .collect::<Result<Vec<EthAbiToken>, _>>()?;
-        JsValue::from_serde(&Self {
+        serde_wasm_bindgen::to_value(&Self {
             token: EthAbiToken::Tuple(tokens),
         })
         .map_err(format_to_js_error)
@@ -146,7 +146,7 @@ impl TryFrom<JsValue> for EthContractFunctionArg {
     type Error = JsValue;
 
     fn try_from(val: JsValue) -> Result<Self, Self::Error> {
-        val.into_serde().map_err(format_to_js_error)
+        serde_wasm_bindgen::from_value(val).map_err(format_to_js_error)
     }
 }
 
@@ -265,7 +265,7 @@ pub async fn broadcast_eth_signed_raw_tx(
     let receipt =
         common::broadcast_eth_signed_raw_tx(raw_tx, &web3api_url, polling_interval_ms).await?;
 
-    JsValue::from_serde(&receipt).map_err(format_to_js_error)
+    serde_wasm_bindgen::to_value(&receipt).map_err(format_to_js_error)
 }
 
 /// Parse the json data that meets the walletconnect standard and build raw transaction
@@ -302,7 +302,7 @@ pub async fn query_account_eth_balance(
 ) -> Result<BigInt, JsValue> {
     let balance = get_eth_balance(&address, &web3_api_url).await?;
     Ok(BigInt::new(
-        &JsValue::from_serde(&balance).map_err(format_to_js_error)?,
+        &serde_wasm_bindgen::to_value(&balance).map_err(format_to_js_error)?,
     )?)
 }
 
@@ -368,7 +368,7 @@ pub async fn broadcast_transfer_eth(
     )
     .await?;
 
-    JsValue::from_serde(&receipt).map_err(format_to_js_error)
+    serde_wasm_bindgen::to_value(&receipt).map_err(format_to_js_error)
 }
 
 /// details needed for contract approval transaction
@@ -798,7 +798,7 @@ impl TokenAmount {
     #[wasm_bindgen(constructor)]
     #[allow(clippy::new_ret_no_self)]
     pub fn new(token_id: String, amount: String) -> Result<JsValue, JsValue> {
-        JsValue::from_serde(&Self { token_id, amount }).map_err(format_to_js_error)
+        serde_wasm_bindgen::to_value(&Self { token_id, amount }).map_err(format_to_js_error)
     }
 }
 
@@ -806,7 +806,7 @@ impl TryFrom<JsValue> for TokenAmount {
     type Error = JsValue;
 
     fn try_from(val: JsValue) -> Result<Self, Self::Error> {
-        val.into_serde().map_err(format_to_js_error)
+        serde_wasm_bindgen::from_value(val).map_err(format_to_js_error)
     }
 }
 
@@ -831,7 +831,7 @@ pub async fn broadcast_approval_contract(
     )
     .await?;
 
-    JsValue::from_serde(&receipt).map_err(format_to_js_error)
+    serde_wasm_bindgen::to_value(&receipt).map_err(format_to_js_error)
 }
 
 /// construct, sign and broadcast a transfer of an ERC20/ERC721/ERC1155 token
@@ -855,7 +855,7 @@ pub async fn broadcast_transfer_contract(
     )
     .await?;
 
-    JsValue::from_serde(&receipt).map_err(format_to_js_error)
+    serde_wasm_bindgen::to_value(&receipt).map_err(format_to_js_error)
 }
 
 /// construct, sign and broadcast batch-transfer of an ERC1155 token
@@ -879,7 +879,7 @@ pub async fn broadcast_batch_transfer_contract(
     )
     .await?;
 
-    JsValue::from_serde(&receipt).map_err(format_to_js_error)
+    serde_wasm_bindgen::to_value(&receipt).map_err(format_to_js_error)
 }
 
 /// construct, sign and broadcast a plain transfer of eth/native token
@@ -891,6 +891,6 @@ pub async fn get_eth_transaction_count(
     let nonce = common::get_eth_transaction_count(&address, &web3api_url).await?;
 
     Ok(BigInt::new(
-        &JsValue::from_serde(&nonce).map_err(format_to_js_error)?,
+        &serde_wasm_bindgen::to_value(&nonce).map_err(format_to_js_error)?,
     )?)
 }


### PR DESCRIPTION
Solution: switched to `serde-wasm-bindgen` and upgraded the wasm-bindgen-related crates
