### PR TITLE
Problem: lose ABI parameter type `function` when parsing `EthAbiParamType` from a string (fix #600)

### DIFF
--- a/common/src/node/ethereum/abi.rs
+++ b/common/src/node/ethereum/abi.rs
@@ -74,6 +74,7 @@ impl From<&str> for EthAbiParamType {
             "address" => EthAbiParamType::Address,
             "bool" => EthAbiParamType::Bool,
             "bytes" => EthAbiParamType::Bytes,
+            "function" => EthAbiParamType::FixedBytes(24),
             "h160" => EthAbiParamType::FixedBytes(20),
             "h256" | "secret" | "hash" => EthAbiParamType::FixedBytes(32),
             "h512" | "public" => EthAbiParamType::FixedBytes(64),


### PR DESCRIPTION
Close #600 

Fixed to parse missing type `function` to `EthAbiParamType::FixedBytes(24)`.

# PR Checklist:

- [x] Have you read the [CONTRIBUTING.md](https://github.com/crypto-com/defi-wallet-core-rs/blob/main/CONTRIBUTING.md)?
- [x] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [x] Have you rebased your work on top of the latest main? 
- [x] Have you checked your code compiles? (`cargo build`)
- [x] Have you included tests for any non-trivial functionality?
- [x] Have you checked your code passes the unit tests? (`cargo test`)
- [x] Have you checked your code formatting is correct? (`cargo fmt -- --check --color=auto`)
- [x] Have you checked your basic code style is fine? (`cargo clippy`)
- [x] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`cargo audit`)
- [x] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [x] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-com/defi-wallet-core-rs/blob/main/CHANGELOG.md)?
- [x] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-com/defi-wallet-core-rs/blob/main/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-com/defi-wallet-core-rs/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).