### PR TITLE
Problem: ABI parameter type parsing does not parse tuples (fixes #339)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,6 +1018,8 @@ dependencies = [
  "itertools",
  "lazy_static",
  "once_cell",
+ "pest",
+ "pest_derive",
  "prost 0.10.4",
  "rand 0.6.5",
  "rand 0.7.3",
@@ -2738,6 +2740,50 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb779fcf4bb850fbbb0edc96ff6cf34fd90c4b1a112ce042653280d9a7364048"
+dependencies = [
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502b62a6d0245378b04ffe0a7fb4f4419a4815fce813bd8a0ec89a56e07d67b1"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451e629bf49b750254da26132f1a5a9d11fd8a95a3df51d15c4abd1ba154cb6c"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcec162c71c45e269dfc3fc2916eaeb97feab22993a21bcce4721d08cd7801a6"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha1",
+]
 
 [[package]]
 name = "petgraph"
@@ -4602,6 +4648,12 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "uint"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 default = []
 # This feature is used to dynamically load ABI contracts. It seems to be
 # error-prone and less security for the end user.
-abi-contract = []
+abi-contract = ["pest", "pest_derive"]
 login = ["siwe"]
 uniffi-binding = ["abi-contract", "uniffi", "uniffi_build", "uniffi_macros"]
 qr-code = ["abi-contract", "rustc-hex"]
@@ -29,6 +29,8 @@ ibc = { version = "0.19", default-features = false }
 ibc-proto = { version = "0.20", default-features = false }
 itertools = "0.10"
 lazy_static = "1"
+pest = { version = "2", optional = true }
+pest_derive = { version = "2", optional = true }
 prost = "0.10"
 rand_core = { version = "0.6", features = ["std"] }
 regex = "1"

--- a/common/src/qr_code.rs
+++ b/common/src/qr_code.rs
@@ -250,8 +250,11 @@ impl FromStr for EIP681Request {
                         parameters.push(Parameter::GasPrice(value));
                     }
                     _ => {
-                        let param_type = ParamType::try_from(&EthAbiParamType::from(key))
-                            .map_err(EIP681ParseError::InvalidKey)?;
+                        let param_type = ParamType::try_from(
+                            &EthAbiParamType::from_str(key)
+                                .map_err(EIP681ParseError::InvalidKey)?,
+                        )
+                        .map_err(EIP681ParseError::InvalidKey)?;
                         let value = match param_type {
                             ParamType::Uint(_) | ParamType::Int(_) => {
                                 let value = U256::from_dec_str(value)


### PR DESCRIPTION
Solution: replaced the custom parser with a peg-based generated parser; removed the aliases unsupported by EIP712 and pure ABI types; created a wrapper type for EIP712 to capture the allowed ABI values
