### PR TITLE
Problem: missing support for general contract calls (fixes #517)

### DIFF
--- a/common/src/common.udl
+++ b/common/src/common.udl
@@ -415,6 +415,7 @@ enum EthError {
   "SignatureError",
   "ChainidError",
   "AbiError",
+  "DynamicAbiError",
   "Eip712Error",
   "JsonError",
   "ClientError",

--- a/common/src/transaction/ethereum/abi_contract.rs
+++ b/common/src/transaction/ethereum/abi_contract.rs
@@ -5,7 +5,6 @@ use crate::EthError;
 use ethers::prelude::abi::{Contract, Token};
 
 /// Ethereum ABI token to ffi bind
-#[cfg(feature = "uniffi-binding")]
 #[derive(Debug, Eq, PartialEq)]
 pub enum EthAbiTokenBind {
     Address { data: String },
@@ -20,7 +19,6 @@ pub enum EthAbiTokenBind {
     Tuple { data: Vec<EthAbiTokenBind> },
 }
 
-#[cfg(feature = "uniffi-binding")]
 impl TryFrom<&EthAbiTokenBind> for EthAbiToken {
     type Error = EthError;
     fn try_from(token: &EthAbiTokenBind) -> Result<Self, Self::Error> {

--- a/common/src/transaction/ethereum/error.rs
+++ b/common/src/transaction/ethereum/error.rs
@@ -44,6 +44,8 @@ pub enum EthError {
     ChainidError(#[from] ParseChainError),
     #[error("ABI error: {0}")]
     AbiError(#[from] abi::Error),
+    #[error("Dynamic ABI error: {0}")]
+    DynamicAbiError(#[from] ethers::abi::AbiError),
     #[error("EIP-712 error: {0}")]
     Eip712Error(#[from] Eip712Error),
     #[error("Json parse error{0}")]


### PR DESCRIPTION
Solution: added a basic contract call creation using the raw ABI strings
