### PR TITLE
Problem: upgrading to uniffi 0.21 fails (fixes #633)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4710,9 +4710,9 @@ checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "uniffi"
-version = "0.19.6"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea179ddeb64c249977c165b1d9f94af9c0a12a4f623e5986f553276612ea8796"
+checksum = "f54af5ada67d1173457a99a7bb44a7917f63e7466764cb4714865c7a6678b830"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4727,9 +4727,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.19.6"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8849753c67126dd7e4f309d09b696378481bfe9b3f5cec0a0c2b8e27391789c8"
+checksum = "12cc4af3c0180c7e86c4a3acf2b6587af04ba2567b1e948993df10f421796621"
 dependencies = [
  "anyhow",
  "askama",
@@ -4750,9 +4750,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.19.6"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6c6fedf97b345227270837fcfd8d9a799f202af7fa843298c788fb943b159f"
+checksum = "510287c368a9386eb731ebe824a6fc6c82a105e20d020af1aa20519c1c1561db"
 dependencies = [
  "anyhow",
  "camino",
@@ -4761,9 +4761,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.19.6"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090e5a993b51dc02faa0dc135ce94f02f050791bda283a5ae9f40fc9a4389a39"
+checksum = "5c8604503caa2cbcf271578dc51ca236d40e3b22e1514ffa2e638e2c39f6ad10"
 dependencies = [
  "bincode",
  "camino",
@@ -4780,9 +4780,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.19.6"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d099cea0c721294ec11ae6c39d661c96d13d8994247ffadaf1576b065e38e6"
+checksum = "cd9417cc653937681436b93838d8c5f97a5b8c58697813982ee8810bd1dc3b57"
 dependencies = [
  "serde",
 ]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -46,8 +46,8 @@ tendermint = "0.23"
 tendermint-proto = "0.23"
 tendermint-rpc = "0.23"
 thiserror = "1"
-uniffi = { version = "^0.19", optional = true }
-uniffi_macros = { version = "^0.19", optional = true }
+uniffi = { version = "^0.21", optional = true }
+uniffi_macros = { version = "^0.21", optional = true }
 url = "2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -73,4 +73,4 @@ tonic = { version = "0.8", default-features = false, features = ["codegen", "pro
 once_cell = "1"
 
 [build-dependencies]
-uniffi_build = { version = "^0.19", features=["builtin-bindgen"], optional = true }
+uniffi_build = { version = "^0.21", features=["builtin-bindgen"], optional = true }


### PR DESCRIPTION
Solution: bump uniffi crates together
