### PR TITLE
Problem: upgrade to siwe 0.5 fails (fixes #644)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding 0.1.5",
+ "block-padding",
  "byte-tools",
  "byteorder",
  "generic-array 0.12.4",
@@ -407,7 +407,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding 0.2.1",
  "generic-array 0.14.6",
 ]
 
@@ -428,12 +427,6 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bs58"
@@ -690,7 +683,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2 0.10.2",
- "sha3 0.10.2",
+ "sha3",
  "thiserror",
 ]
 
@@ -1294,7 +1287,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.2",
- "sha3 0.10.2",
+ "sha3",
  "thiserror",
  "uuid",
 ]
@@ -1311,7 +1304,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha3 0.10.2",
+ "sha3",
  "thiserror",
  "uint",
 ]
@@ -2146,7 +2139,7 @@ dependencies = [
  "prost 0.11.0",
  "ripemd",
  "sha2 0.10.2",
- "sha3 0.10.2",
+ "sha3",
 ]
 
 [[package]]
@@ -2253,11 +2246,12 @@ checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "iri-string"
-version = "0.4.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f0f7638c1e223529f1bfdc48c8b133b9e0b434094d1d28473161ee48b235f78"
+checksum = "6d0586ad318a04c73acdbad33f67969519b5452c80770c4c72059a686da48a7e"
 dependencies = [
- "nom",
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -2303,7 +2297,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "sha2 0.10.2",
- "sha3 0.10.2",
+ "sha3",
 ]
 
 [[package]]
@@ -3901,18 +3895,6 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "sha3"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a31480366ec990f395a61b7c08122d99bd40544fdb5abcfc1b06bb29994312c"
@@ -3948,16 +3930,16 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "siwe"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f24fe2b646c33a670e7d79a232bffb41821fed28b1870a8bd1a47e6ae686ace6"
+checksum = "ec4cc2eafb2354c1aeaeac5f53b7726ca4ea5ad16314a0b5ebacb6676f599c2b"
 dependencies = [
  "hex",
  "http",
  "iri-string",
  "k256",
  "rand 0.8.5",
- "sha3 0.9.1",
+ "sha3",
  "thiserror",
  "time",
 ]

--- a/bindings/cpp/Cargo.toml
+++ b/bindings/cpp/Cargo.toml
@@ -13,7 +13,7 @@ cxx = "1"
 anyhow = "1"
 serde="1"
 serde_json="1"
-siwe = { version = "0.4" }
+siwe = { version = "0.5" }
 ethers = { version = "0.17", features = ["rustls"] }
 hex = "0.4"
 tokio = { version = "1", features = ["rt"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -41,7 +41,7 @@ secrecy = "0.8"
 serde = "1"
 serde_json = "1"
 serde_with = "2"
-siwe = { version = "0.4", optional = true }
+siwe = { version = "0.5", optional = true }
 tendermint = "0.23"
 tendermint-proto = "0.23"
 tendermint-rpc = "0.23"


### PR DESCRIPTION
Solution: adjusted the API usage (verify is now async, because it could take the HTTP provider for additional verification against onchain state)
