### PR TITLE
Problem: error is generated if set_ethers_httpagent called after get_ethers_provider fix (#676)

### DIFF
--- a/common/src/node/ethereum/provider.rs
+++ b/common/src/node/ethereum/provider.rs
@@ -30,17 +30,15 @@ pub async fn get_ethers_provider(urlinfo: &str) -> Result<Provider<Http>, EthErr
 
     #[cfg(not(target_arch = "wasm32"))]
     let client = {
-        let agentinfo: String = G_AGENTINFO
-            .get_or_init(|| {
-                std::env::var("DEFIWALLETCORE_AGENTINFO")
-                    .unwrap_or_else(|_| "defiwalletcore".to_string())
-            })
-            .clone();
-
-        reqwest::Client::builder()
-            .user_agent(agentinfo)
-            .build()
-            .map_err(EthError::ClientError)?
+        match G_AGENTINFO.get() {
+            Some(v) => reqwest::Client::builder()
+                .user_agent(v)
+                .build()
+                .map_err(EthError::ClientError)?,
+            None => reqwest::Client::builder()
+                .build()
+                .map_err(EthError::ClientError)?,
+        }
     };
 
     let httpprovider = Http::new_with_client(url, client);

--- a/common/src/node/ethereum/provider.rs
+++ b/common/src/node/ethereum/provider.rs
@@ -36,6 +36,10 @@ pub async fn get_ethers_provider(urlinfo: &str) -> Result<Provider<Http>, EthErr
                 .build()
                 .map_err(EthError::ClientError)?,
             None => reqwest::Client::builder()
+                .user_agent(
+                    std::env::var("DEFIWALLETCORE_AGENTINFO")
+                        .unwrap_or_else(|_| "defiwalletcore".to_string()),
+                )
                 .build()
                 .map_err(EthError::ClientError)?,
         }


### PR DESCRIPTION
Close:
- #676

Solution:
- Only get `G_AGENTINFO` in get_ethers_provider

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-com/defi-wallet-core-rs/blob/main/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest main? 
- [ ] Have you checked your code compiles? (`cargo build`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`cargo test`)
- [ ] Have you checked your code formatting is correct? (`cargo fmt -- --check --color=auto`)
- [ ] Have you checked your basic code style is fine? (`cargo clippy`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`cargo audit`)
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-com/defi-wallet-core-rs/blob/main/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-com/defi-wallet-core-rs/blob/main/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-com/defi-wallet-core-rs/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Thank you for your code, it's appreciated! :)
