### PR TITLE
Problem: upgrade to tendermint 0.28 fails (fixes #705)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,9 +785,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673d31bd830c0772d78545de20d975129b6ab2f7db4e4e9313c3b8777d319194"
+checksum = "c4776e787b24d9568dd61d3237eeb4eb321d622fb881b858c7b82806420e87d4"
 dependencies = [
  "prost",
  "prost-types",
@@ -797,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "cosmrs"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa07096219b1817432b8f1e47c22e928c64bbfd231fc08f0a98f0e7ddd602b7"
+checksum = "424675b6cf29795e5db8a808a78dd4229f0fdf90f64d9286dec0490f62534003"
 dependencies = [
  "bip32",
  "cosmos-sdk-proto",
@@ -2084,9 +2084,9 @@ dependencies = [
 
 [[package]]
 name = "ibc"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa217b0a0c2f802d62da15e8d8380d28d4a7b1affcf5c494266c618508999de3"
+checksum = "a9b5747af80b8dc7af6b3d3e1929d8124479e99b07e8b65d07f8fff531b67bda"
 dependencies = [
  "bytes",
  "derive_more",
@@ -2114,9 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-proto"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874af3f9f3fe1a3458e54b1d4ebb2ab1fadc22b02470eb2d623a59f3c7d907c0"
+checksum = "761c5a16ce1ac9943bfd46ddad61512a0e5e02f527abed578b7fae342c8cd5e2"
 dependencies = [
  "base64 0.13.1",
  "bytes",
@@ -2129,9 +2129,9 @@ dependencies = [
 
 [[package]]
 name = "ics23"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "149f3093d710c18c749ba68de3bc8131927aca00410ab90f3368e0524d01fe90"
+checksum = "ca44b684ce1859cff746ff46f5765ab72e12e3c06f76a8356db8f9a2ecf43f17"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3994,11 +3994,10 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa1d2d0ec1b531ba7d196f0dbee5e78ed2a82bfba928e88dff64aeec0b26073"
+checksum = "eeb6f9c129bc9f1a3c38bc91c63a5e8d3c00ed998e7fa4ca44e06467466d0e77"
 dependencies = [
- "async-trait",
  "bytes",
  "ed25519",
  "ed25519-dalek",
@@ -4025,9 +4024,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-config"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "202a2f19502c03b353d8157694ed24fbc58c3dd64a92a5b0cb80b79c82af5be4"
+checksum = "414d0e7b47e20accc2e950fa623e76269eb0daeb8a20b6d7af2a61211f2806bf"
 dependencies = [
  "flex-error",
  "serde",
@@ -4039,9 +4038,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-light-client-verifier"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66e3e75f9be6260fab5d5c9a6688885c478c3d3a14c66c2fde80c78769c20ee"
+checksum = "56df17ee76ef1e482804443b0d66673d2c8be38ad58913c09120b64d35777aba"
 dependencies = [
  "derive_more",
  "flex-error",
@@ -4052,9 +4051,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-proto"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "974d6330a19dfa6720e9f663fc59101d207a817db3f9c730d3f31caaa565b574"
+checksum = "d5895470f28c530f8ae8c4071bf8190304ce00bd131d25e81730453124a3375c"
 dependencies = [
  "bytes",
  "flex-error",
@@ -4070,9 +4069,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-rpc"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5d87fa5429bd2ee39c4809dd546096daf432de9b71157bc12c182ab5bae7ea7"
+checksum = "367e0417ca8bb40edc0a7af65600840f7c199b0b6109fdb12c5827733bec155f"
 dependencies = [
  "bytes",
  "flex-error",
@@ -4086,7 +4085,6 @@ dependencies = [
  "subtle-encoding",
  "tendermint",
  "tendermint-config",
- "tendermint-proto",
  "thiserror",
  "time",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,8 +786,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 [[package]]
 name = "cosmos-sdk-proto"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4776e787b24d9568dd61d3237eeb4eb321d622fb881b858c7b82806420e87d4"
+source = "git+https://github.com/cosmos/cosmos-rust.git#f5816dfd24663246eb3b444d3fb59b72c07fb9d9"
 dependencies = [
  "prost",
  "prost-types",
@@ -798,8 +797,7 @@ dependencies = [
 [[package]]
 name = "cosmrs"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424675b6cf29795e5db8a808a78dd4229f0fdf90f64d9286dec0490f62534003"
+source = "git+https://github.com/cosmos/cosmos-rust.git#f5816dfd24663246eb3b444d3fb59b72c07fb9d9"
 dependencies = [
  "bip32",
  "cosmos-sdk-proto",
@@ -1189,6 +1187,17 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2084,15 +2093,15 @@ dependencies = [
 
 [[package]]
 name = "ibc"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b5747af80b8dc7af6b3d3e1929d8124479e99b07e8b65d07f8fff531b67bda"
+checksum = "ef65a54b072a0df0ce9346485d9cdd50ee27bb0056871b1762b58c628d586dde"
 dependencies = [
  "bytes",
  "derive_more",
+ "displaydoc",
  "dyn-clone",
  "erased-serde",
- "flex-error",
  "ibc-proto",
  "ics23",
  "num-traits",
@@ -2114,9 +2123,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-proto"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761c5a16ce1ac9943bfd46ddad61512a0e5e02f527abed578b7fae342c8cd5e2"
+checksum = "32e01271bba1bcd3065da99a2288bdc2b539045c780b641bfe40076fdb4c211c"
 dependencies = [
  "base64 0.13.1",
  "bytes",
@@ -3994,9 +4003,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb6f9c129bc9f1a3c38bc91c63a5e8d3c00ed998e7fa4ca44e06467466d0e77"
+checksum = "c518c082146825f10d6f9a32159ae46edcfd7dae8ac630c8067594bb2a784d72"
 dependencies = [
  "bytes",
  "ed25519",
@@ -4024,9 +4033,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-config"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414d0e7b47e20accc2e950fa623e76269eb0daeb8a20b6d7af2a61211f2806bf"
+checksum = "6f58b86374e3bcfc8135770a6c55388fce101c00de4a5f03224fa5830c9240b7"
 dependencies = [
  "flex-error",
  "serde",
@@ -4038,9 +4047,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-light-client-verifier"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56df17ee76ef1e482804443b0d66673d2c8be38ad58913c09120b64d35777aba"
+checksum = "c742bb914f9fb025ce0e481fbef9bb59c94d5a4bbd768798102675a2e0fb7440"
 dependencies = [
  "derive_more",
  "flex-error",
@@ -4051,9 +4060,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-proto"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5895470f28c530f8ae8c4071bf8190304ce00bd131d25e81730453124a3375c"
+checksum = "890f1fb6dee48900c85f0cdf711ebf130e505ac09ad918cee5c34ed477973b05"
 dependencies = [
  "bytes",
  "flex-error",
@@ -4069,9 +4078,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-rpc"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "367e0417ca8bb40edc0a7af65600840f7c199b0b6109fdb12c5827733bec155f"
+checksum = "06df4715f9452ec0a21885d6da8d804799455ba50d8bc40be1ec1c800afd4bd8"
 dependencies = [
  "bytes",
  "flex-error",

--- a/bindings/cpp/Cargo.toml
+++ b/bindings/cpp/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 [dependencies]
 defi-wallet-core-common = { path = "../../common" , features=["login","abi-contract"]}
 defi-wallet-core-proto = { version = "0.1", path = "../../proto" }
-cosmos-sdk-proto = { version = "0.16" }
+cosmos-sdk-proto = { git = "https://github.com/cosmos/cosmos-rust.git" }
 cxx = "1"
 anyhow = "1"
 serde="1"

--- a/bindings/cpp/Cargo.toml
+++ b/bindings/cpp/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 [dependencies]
 defi-wallet-core-common = { path = "../../common" , features=["login","abi-contract"]}
 defi-wallet-core-proto = { version = "0.1", path = "../../proto" }
-cosmos-sdk-proto = { version = "0.15" }
+cosmos-sdk-proto = { version = "0.16" }
 cxx = "1"
 anyhow = "1"
 serde="1"

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -29,14 +29,14 @@ wasm-bindgen = "0.2"
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
 console_error_panic_hook = { version = "0.1", optional = true }
-cosmos-sdk-proto = { version = "0.15", default-features = false, features = ["cosmwasm"] }
+cosmos-sdk-proto = { version = "0.16", default-features = false, features = ["cosmwasm"] }
 
-tendermint = "0.26"
+tendermint = "0.27"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 ethers = { version = "1", features = ["rustls"] }
 wasm-timer = "0.2"
-tendermint-rpc = "0.26"
+tendermint-rpc = "0.27"
 defi-wallet-core-proto = { version = "0.1", path = "../../proto" }
 tonic-web-wasm-client = "0.3"

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -29,14 +29,14 @@ wasm-bindgen = "0.2"
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
 console_error_panic_hook = { version = "0.1", optional = true }
-cosmos-sdk-proto = { version = "0.16", default-features = false, features = ["cosmwasm"] }
+cosmos-sdk-proto = { git = "https://github.com/cosmos/cosmos-rust.git", default-features = false, features = ["cosmwasm"] }
 
-tendermint = "0.27"
+tendermint = "0.28"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 ethers = { version = "1", features = ["rustls"] }
 wasm-timer = "0.2"
-tendermint-rpc = "0.27"
+tendermint-rpc = "0.28"
 defi-wallet-core-proto = { version = "0.1", path = "../../proto" }
 tonic-web-wasm-client = "0.3"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -23,11 +23,11 @@ anyhow = "1"
 base64 = "0.20"
 bech32 = "0.9"
 bip39 = { version = "1", default-features = false }
-cosmrs = "0.11"
+cosmrs = { git = "https://github.com/cosmos/cosmos-rust.git" }
 eyre = "0.6"
 ethers = { version = "1", features = ["rustls", "abigen"] }
-ibc = { version = "0.24", default-features = false }
-ibc-proto = { version = "0.23", default-features = false }
+ibc = { version = "0.25", default-features = false }
+ibc-proto = { version = "0.24", default-features = false }
 itertools = "0.10"
 lazy_static = "1"
 pest = { version = "2", optional = true }
@@ -42,16 +42,16 @@ serde = "1"
 serde_json = "1"
 serde_with = "2"
 siwe = { version = "0.5", optional = true }
-tendermint = "0.27"
-tendermint-proto = "0.27"
-tendermint-rpc = "0.27"
+tendermint = "0.28"
+tendermint-proto = "0.28"
+tendermint-rpc = "0.28"
 thiserror = "1"
 uniffi = { version = "^0.21", optional = true }
 uniffi_macros = { version = "^0.22", optional = true }
 url = "2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-cosmos-sdk-proto = { version = "0.16", default-features = false, features = ["cosmwasm", "grpc"] }
+cosmos-sdk-proto = { git = "https://github.com/cosmos/cosmos-rust.git", default-features = false, features = ["cosmwasm", "grpc"] }
 defi-wallet-core-proto = { version = "0.1", path = "../proto" }
 rand = { version = "0.8", default-features = false, features = ["getrandom"] }
 tonic = { version = "0.8", default-features = false, features = ["codegen", "prost"] }
@@ -61,7 +61,7 @@ wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 tonic-web-wasm-client = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-cosmos-sdk-proto = { version = "0.16", features = ["grpc"] }
+cosmos-sdk-proto = { git = "https://github.com/cosmos/cosmos-rust.git", features = ["grpc"] }
 defi-wallet-core-proto = { version = "0.1", path = "../proto", features = ["transport"] }
 rand = "0.8"
 tokio = { version = "1", features = ["rt"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -23,11 +23,11 @@ anyhow = "1"
 base64 = "0.20"
 bech32 = "0.9"
 bip39 = { version = "1", default-features = false }
-cosmrs = "0.10"
+cosmrs = "0.11"
 eyre = "0.6"
 ethers = { version = "1", features = ["rustls", "abigen"] }
-ibc = { version = "0.23", default-features = false }
-ibc-proto = { version = "0.22", default-features = false }
+ibc = { version = "0.24", default-features = false }
+ibc-proto = { version = "0.23", default-features = false }
 itertools = "0.10"
 lazy_static = "1"
 pest = { version = "2", optional = true }
@@ -42,16 +42,16 @@ serde = "1"
 serde_json = "1"
 serde_with = "2"
 siwe = { version = "0.5", optional = true }
-tendermint = "0.26"
-tendermint-proto = "0.26"
-tendermint-rpc = "0.26"
+tendermint = "0.27"
+tendermint-proto = "0.27"
+tendermint-rpc = "0.27"
 thiserror = "1"
 uniffi = { version = "^0.21", optional = true }
 uniffi_macros = { version = "^0.22", optional = true }
 url = "2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-cosmos-sdk-proto = { version = "0.15", default-features = false, features = ["cosmwasm", "grpc"] }
+cosmos-sdk-proto = { version = "0.16", default-features = false, features = ["cosmwasm", "grpc"] }
 defi-wallet-core-proto = { version = "0.1", path = "../proto" }
 rand = { version = "0.8", default-features = false, features = ["getrandom"] }
 tonic = { version = "0.8", default-features = false, features = ["codegen", "prost"] }
@@ -61,7 +61,7 @@ wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 tonic-web-wasm-client = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-cosmos-sdk-proto = { version = "0.15", features = ["grpc"] }
+cosmos-sdk-proto = { version = "0.16", features = ["grpc"] }
 defi-wallet-core-proto = { version = "0.1", path = "../proto", features = ["transport"] }
 rand = "0.8"
 tokio = { version = "1", features = ["rt"] }

--- a/common/src/node/cosmos_sdk.rs
+++ b/common/src/node/cosmos_sdk.rs
@@ -214,9 +214,7 @@ pub async fn broadcast_tx_sync(
     tendermint_rpc_url: &str,
     raw_signed_tx: Vec<u8>,
 ) -> Result<response::Wrapper<tx_sync::Response>, RestError> {
-    let request = request::Wrapper::new(tx_sync::Request {
-        tx: raw_signed_tx.into(),
-    });
+    let request = request::Wrapper::new(tx_sync::Request { tx: raw_signed_tx });
 
     reqwest::Client::new()
         .post(tendermint_rpc_url)

--- a/common/src/transaction/cosmos_sdk.rs
+++ b/common/src/transaction/cosmos_sdk.rs
@@ -590,14 +590,18 @@ impl CosmosSDKMsg {
                 timeout_timestamp,
             } => {
                 let any = MsgTransfer {
-                    sender: Signer::from_str(sender_address.as_ref())?,
-                    receiver: Signer::from_str(receiver)?,
-                    source_port: PortId::from_str(source_port)?,
-                    source_channel: ChannelId::from_str(source_channel)?,
+                    sender: Signer::from_str(sender_address.as_ref())
+                        .map_err(|e| eyre::eyre!("{e}"))?,
+                    receiver: Signer::from_str(receiver).map_err(|e| eyre::eyre!("{e}"))?,
+                    source_port: PortId::from_str(source_port).map_err(|e| eyre::eyre!("{e}"))?,
+                    source_channel: ChannelId::from_str(source_channel)
+                        .map_err(|e| eyre::eyre!("{e}"))?,
                     token: token.try_into()?,
                     // TODO: timeout_height and timeout_timestamp cannot both be 0.
-                    timeout_height: TimeoutHeight::try_from(timeout_height.clone())?,
-                    timeout_timestamp: Timestamp::from_nanoseconds(*timeout_timestamp)?,
+                    timeout_height: TimeoutHeight::try_from(timeout_height.clone())
+                        .map_err(|e| eyre::eyre!("{e}"))?,
+                    timeout_timestamp: Timestamp::from_nanoseconds(*timeout_timestamp)
+                        .map_err(|e| eyre::eyre!("{e}"))?,
                 }
                 .to_any();
                 // FIXME:

--- a/common/src/transaction/cosmos_sdk/parser/structs/cosmos_raw_msg.rs
+++ b/common/src/transaction/cosmos_sdk/parser/structs/cosmos_raw_msg.rs
@@ -384,14 +384,17 @@ impl CosmosRawNormalMsg {
                 timeout_timestamp,
             } => {
                 let any = MsgTransfer {
-                    sender: Signer::from_str(sender)?,
-                    receiver: Signer::from_str(receiver)?,
-                    source_port: PortId::from_str(source_port)?,
-                    source_channel: ChannelId::from_str(source_channel)?,
+                    sender: Signer::from_str(sender).map_err(|e| eyre::eyre!("{e}"))?,
+                    receiver: Signer::from_str(receiver).map_err(|e| eyre::eyre!("{e}"))?,
+                    source_port: PortId::from_str(source_port).map_err(|e| eyre::eyre!("{e}"))?,
+                    source_channel: ChannelId::from_str(source_channel)
+                        .map_err(|e| eyre::eyre!("{e}"))?,
                     token: token.try_into()?,
                     // TODO: timeout_height and timeout_timestamp cannot both be 0.
-                    timeout_height: TimeoutHeight::try_from(timeout_height.clone())?,
-                    timeout_timestamp: Timestamp::from_nanoseconds(*timeout_timestamp)?,
+                    timeout_height: TimeoutHeight::try_from(timeout_height.clone())
+                        .map_err(|e| eyre::eyre!("{e}"))?,
+                    timeout_timestamp: Timestamp::from_nanoseconds(*timeout_timestamp)
+                        .map_err(|e| eyre::eyre!("{e}"))?,
                 }
                 .to_any();
                 // FIXME:

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -11,11 +11,11 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-cosmrs = "0.11"
-cosmos-sdk-proto = { version = "0.16", default-features = false }
+cosmrs = { git = "https://github.com/cosmos/cosmos-rust.git" }
+cosmos-sdk-proto = { git = "https://github.com/cosmos/cosmos-rust.git", default-features = false }
 prost = "0.11"
 prost-types = "0.11"
-tendermint-proto = "0.27"
+tendermint-proto = "0.28"
 tonic = { version = "0.8", default-features = false, features = ["codegen", "prost"] }
 serde = "1"
 

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -11,11 +11,11 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-cosmrs = "0.10"
-cosmos-sdk-proto = { version = "0.15", default-features = false }
+cosmrs = "0.11"
+cosmos-sdk-proto = { version = "0.16", default-features = false }
 prost = "0.11"
 prost-types = "0.11"
-tendermint-proto = "0.26"
+tendermint-proto = "0.27"
 tonic = { version = "0.8", default-features = false, features = ["codegen", "prost"] }
 serde = "1"
 


### PR DESCRIPTION
Solution: bumped all related crates (ibc, cosmrs, proto ones...) together
