### PR TITLE
Problem: upgrade to uniffi 0.22 fails (fixes #758)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,19 +530,6 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "cargo_metadata"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "982a0cf6a99c350d7246035613882e376d58cebe571785abc5da4f648d53ac0a"
@@ -1044,8 +1031,8 @@ dependencies = [
  "tonic",
  "tonic-web-wasm-client",
  "uniffi",
- "uniffi_build 0.21.0",
- "uniffi_macros 0.22.0",
+ "uniffi_build",
+ "uniffi_macros",
  "url",
  "wasm-bindgen",
 ]
@@ -1460,7 +1447,7 @@ checksum = "ade3e9c97727343984e1ceada4fdab11142d2ee3472d2c67027d56b1251d4f15"
 dependencies = [
  "arrayvec",
  "bytes",
- "cargo_metadata 0.15.2",
+ "cargo_metadata",
  "chrono",
  "convert_case",
  "elliptic-curve",
@@ -1876,9 +1863,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "goblin"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7666983ed0dd8d21a6f6576ee00053ca0926fb281a5522577a4dbd0f1b54143"
+checksum = "572564d6cba7d09775202c8e7eebc4d534d5ae36578ab402fb21e182a0ac9505"
 dependencies = [
  "log",
  "plain",
@@ -4571,33 +4558,32 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "uniffi"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54af5ada67d1173457a99a7bb44a7917f63e7466764cb4714865c7a6678b830"
+checksum = "8e7057bad60ea5f6e2c2df43dbc8143880d19daca2d9bb0ef81131b37ef42cc9"
 dependencies = [
  "anyhow",
  "bytes",
  "camino",
- "cargo_metadata 0.14.2",
  "log",
  "once_cell",
  "paste",
  "static_assertions",
- "uniffi_macros 0.21.0",
+ "uniffi_macros",
 ]
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc4af3c0180c7e86c4a3acf2b6587af04ba2567b1e948993df10f421796621"
+checksum = "19d84dea610e893f4043354c71e4361386475365e6e2834aded4c8cebf940311"
 dependencies = [
  "anyhow",
  "askama",
  "bincode",
  "camino",
- "clap",
  "fs-err",
+ "glob",
  "goblin",
  "heck",
  "once_cell",
@@ -4605,19 +4591,9 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
- "uniffi_meta 0.21.0",
+ "uniffi_meta",
+ "uniffi_testing",
  "weedle2",
-]
-
-[[package]]
-name = "uniffi_build"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510287c368a9386eb731ebe824a6fc6c82a105e20d020af1aa20519c1c1561db"
-dependencies = [
- "anyhow",
- "camino",
- "uniffi_bindgen",
 ]
 
 [[package]]
@@ -4628,6 +4604,7 @@ checksum = "6db116cd55ae857fd40d5780d47c76d3f6aa68c242458fb57bc24cb130a3e920"
 dependencies = [
  "anyhow",
  "camino",
+ "uniffi_bindgen",
 ]
 
 [[package]]
@@ -4638,25 +4615,6 @@ checksum = "f55105cc7e1ac83ca1eb29587e3b7f65737f9142dc65d54b63502c2589c9d6a5"
 dependencies = [
  "quote",
  "syn",
-]
-
-[[package]]
-name = "uniffi_macros"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8604503caa2cbcf271578dc51ca236d40e3b22e1514ffa2e638e2c39f6ad10"
-dependencies = [
- "bincode",
- "camino",
- "fs-err",
- "once_cell",
- "proc-macro2",
- "quote",
- "serde",
- "syn",
- "toml",
- "uniffi_build 0.21.0",
- "uniffi_meta 0.21.0",
 ]
 
 [[package]]
@@ -4674,17 +4632,8 @@ dependencies = [
  "serde",
  "syn",
  "toml",
- "uniffi_build 0.22.0",
- "uniffi_meta 0.22.0",
-]
-
-[[package]]
-name = "uniffi_meta"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9417cc653937681436b93838d8c5f97a5b8c58697813982ee8810bd1dc3b57"
-dependencies = [
- "serde",
+ "uniffi_build",
+ "uniffi_meta",
 ]
 
 [[package]]
@@ -4696,6 +4645,21 @@ dependencies = [
  "serde",
  "siphasher",
  "uniffi_checksum_derive",
+]
+
+[[package]]
+name = "uniffi_testing"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cd68c90ec2ab35abc868eae85eedd92b7cede34d38a57e356fce96b8f99d4ef"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "once_cell",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -46,7 +46,7 @@ tendermint = "0.26"
 tendermint-proto = "0.26"
 tendermint-rpc = "0.26"
 thiserror = "1"
-uniffi = { version = "^0.21", optional = true }
+uniffi = { version = "^0.22", optional = true }
 uniffi_macros = { version = "^0.22", optional = true }
 url = "2"
 
@@ -69,4 +69,4 @@ tonic = { version = "0.8", default-features = false, features = ["codegen", "pro
 once_cell = "1"
 
 [build-dependencies]
-uniffi_build = { version = "^0.21", features=["builtin-bindgen"], optional = true }
+uniffi_build = { version = "^0.22", features=["builtin-bindgen"], optional = true }


### PR DESCRIPTION
Solution: bump the related uniffi crates together
