### PR TITLE
Problem: upgrading to ibc 0.27 fails (fixes #787)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +509,51 @@ name = "block-padding"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
+
+[[package]]
+name = "borsh"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
+dependencies = [
+ "borsh-derive",
+ "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
+dependencies = [
+ "borsh-derive-internal",
+ "borsh-schema-derive-internal",
+ "proc-macro-crate 0.1.5",
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "borsh-derive-internal"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "borsh-schema-derive-internal"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "bs58"
@@ -2037,6 +2093,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -2233,9 +2298,9 @@ dependencies = [
 
 [[package]]
 name = "ibc"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef65a54b072a0df0ce9346485d9cdd50ee27bb0056871b1762b58c628d586dde"
+checksum = "22a730a189bda73e2d2ac215b49fd2c533388b966dd59c9d7550e520f6b9e711"
 dependencies = [
  "bytes",
  "derive_more",
@@ -2268,9 +2333,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b46bcc4540116870cfb184f338b45174a7560ad46dd74e4cb4e81e005e2056"
 dependencies = [
  "base64 0.13.1",
+ "borsh",
  "bytes",
  "flex-error",
+ "parity-scale-codec",
  "prost",
+ "scale-info",
  "serde",
  "subtle-encoding",
  "tendermint-proto",
@@ -2358,7 +2426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
  "serde",
 ]
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -26,7 +26,7 @@ bip39 = { version = "1", default-features = false }
 cosmrs = { git = "https://github.com/cosmos/cosmos-rust.git" }
 eyre = "0.6"
 ethers = { version = "1", features = ["rustls", "abigen"] }
-ibc = { version = "0.25", default-features = false }
+ibc = { version = "0.27", features = ["serde"], default-features = false }
 ibc-proto = { version = "0.24", default-features = false }
 itertools = "0.10"
 lazy_static = "1"

--- a/common/src/transaction/cosmos_sdk.rs
+++ b/common/src/transaction/cosmos_sdk.rs
@@ -593,14 +593,14 @@ impl CosmosSDKMsg {
                     sender: Signer::from_str(sender_address.as_ref())
                         .map_err(|e| eyre::eyre!("{e}"))?,
                     receiver: Signer::from_str(receiver).map_err(|e| eyre::eyre!("{e}"))?,
-                    source_port: PortId::from_str(source_port).map_err(|e| eyre::eyre!("{e}"))?,
-                    source_channel: ChannelId::from_str(source_channel)
+                    port_on_a: PortId::from_str(source_port).map_err(|e| eyre::eyre!("{e}"))?,
+                    chan_on_a: ChannelId::from_str(source_channel)
                         .map_err(|e| eyre::eyre!("{e}"))?,
                     token: token.try_into()?,
                     // TODO: timeout_height and timeout_timestamp cannot both be 0.
-                    timeout_height: TimeoutHeight::try_from(timeout_height.clone())
+                    timeout_height_on_b: TimeoutHeight::try_from(timeout_height.clone())
                         .map_err(|e| eyre::eyre!("{e}"))?,
-                    timeout_timestamp: Timestamp::from_nanoseconds(*timeout_timestamp)
+                    timeout_timestamp_on_b: Timestamp::from_nanoseconds(*timeout_timestamp)
                         .map_err(|e| eyre::eyre!("{e}"))?,
                 }
                 .to_any();

--- a/common/src/transaction/cosmos_sdk/parser/structs/cosmos_raw_msg.rs
+++ b/common/src/transaction/cosmos_sdk/parser/structs/cosmos_raw_msg.rs
@@ -145,14 +145,14 @@ impl TryFrom<MsgTransfer> for CosmosRawMsg {
             msg: CosmosRawNormalMsg::IbcTransfer {
                 sender: msg.sender.to_string(),
                 receiver: msg.receiver.to_string(),
-                source_port: msg.source_port.to_string(),
-                source_channel: msg.source_channel.to_string(),
+                source_port: msg.port_on_a.to_string(),
+                source_channel: msg.chan_on_a.to_string(),
                 token: msg.token.into(),
-                timeout_height: match msg.timeout_height {
+                timeout_height: match msg.timeout_height_on_b {
                     TimeoutHeight::Never => Height::default(),
                     TimeoutHeight::At(height) => height.into(),
                 },
-                timeout_timestamp: msg.timeout_timestamp.nanoseconds(),
+                timeout_timestamp: msg.timeout_timestamp_on_b.nanoseconds(),
             },
         })
     }
@@ -386,14 +386,14 @@ impl CosmosRawNormalMsg {
                 let any = MsgTransfer {
                     sender: Signer::from_str(sender).map_err(|e| eyre::eyre!("{e}"))?,
                     receiver: Signer::from_str(receiver).map_err(|e| eyre::eyre!("{e}"))?,
-                    source_port: PortId::from_str(source_port).map_err(|e| eyre::eyre!("{e}"))?,
-                    source_channel: ChannelId::from_str(source_channel)
+                    port_on_a: PortId::from_str(source_port).map_err(|e| eyre::eyre!("{e}"))?,
+                    chan_on_a: ChannelId::from_str(source_channel)
                         .map_err(|e| eyre::eyre!("{e}"))?,
                     token: token.try_into()?,
                     // TODO: timeout_height and timeout_timestamp cannot both be 0.
-                    timeout_height: TimeoutHeight::try_from(timeout_height.clone())
+                    timeout_height_on_b: TimeoutHeight::try_from(timeout_height.clone())
                         .map_err(|e| eyre::eyre!("{e}"))?,
-                    timeout_timestamp: Timestamp::from_nanoseconds(*timeout_timestamp)
+                    timeout_timestamp_on_b: Timestamp::from_nanoseconds(*timeout_timestamp)
                         .map_err(|e| eyre::eyre!("{e}"))?,
                 }
                 .to_any();


### PR DESCRIPTION
Solution: added a feature flag and adapted the msgtransfer fields based on the breaking changes
