### PR TITLE
Problem: upgrading base64 to 0.21 fails (fixes #775)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,7 +1121,7 @@ name = "defi-wallet-core-common"
 version = "0.3.2"
 dependencies = [
  "anyhow",
- "base64 0.20.0",
+ "base64 0.21.0",
  "bech32 0.9.1",
  "bip39",
  "cosmos-sdk-proto",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -20,7 +20,7 @@ erc4907 = []
 
 [dependencies]
 anyhow = "1"
-base64 = "0.20"
+base64 = "0.21"
 bech32 = "0.9"
 bip39 = { version = "1", default-features = false }
 cosmrs = { git = "https://github.com/cosmos/cosmos-rust.git" }

--- a/common/src/transaction/cosmos_sdk/parser/structs.rs
+++ b/common/src/transaction/cosmos_sdk/parser/structs.rs
@@ -3,6 +3,7 @@
 // moved to `cosmos_sdk.rs` if reusable.
 
 use crate::transaction::cosmos_sdk::{CosmosError, SingleCoin};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use cosmrs::crypto::{LegacyAminoMultisig, PublicKey};
 use cosmrs::tx::{mode_info, AuthInfo, Body, Fee, ModeInfo, SignerInfo, SignerPublicKey};
 use itertools::Itertools;
@@ -26,7 +27,7 @@ impl From<cosmrs::Any> for CosmosAny {
     fn from(any: cosmrs::Any) -> Self {
         Self {
             type_url: any.type_url,
-            value: base64::encode(any.value),
+            value: STANDARD.encode(&any.value),
         }
     }
 }


### PR DESCRIPTION
Solution: changed from the deprecated method to the current base64 API
